### PR TITLE
Add docs badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 
 [![Build Status](https://travis-ci.org/silexlabs/Silex.png?branch=master)](https://travis-ci.org/silexlabs/Silex)
 [![Code Climate](https://codeclimate.com/github/silexlabs/Silex/badges/gpa.svg)](https://codeclimate.com/github/silexlabs/Silex)
+[![Inline docs](http://inch-ci.org/github/silexlabs/Silex.svg?branch=master)](http://inch-ci.org/github/silexlabs/Silex)
 [![Dependency Status](https://gemnasium.com/silexlabs/Silex.png)](https://gemnasium.com/silexlabs/Silex)
 [![Stories in Ready](https://badge.waffle.io/silexlabs/silex.png?label=ready)](http://waffle.io/silexlabs/silex)
 [![Analytics](https://ga-beacon.appspot.com/UA-19608894-21/silexlabs/Silex)](https://github.com/igrigorik/ga-beacon)


### PR DESCRIPTION
Hi there,

you have recently tried to evaluate this project via Inch. I took the liberty to make a badge for you: [![Inline docs](http://inch-ci.org/github/silexlabs/Silex.svg)](http://inch-ci.org/github/silexlabs/Silex)

The badge shows an evaluation by [InchJS](http://trivelop.de/inchjs), but I guess you already knew that. :wink: 

I would really like to roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [Shipit](https://github.com/shipitjs/shipit)).

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/silexlabs/Silex

What do you think?