### PR TITLE
Fixes fat docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY . /silex
 WORKDIR /silex
 RUN apt-get update \
 &&  apt-get install -yq python openjdk-7-jre \
+&&  rm -rf /var/lib/apt/lists/* \
 &&  make
 
 EXPOSE 6805


### PR DESCRIPTION
In a Dockerfile, if you don't do this `rm` thing,  the image stays with all apt tree. This commit makes the image slimmer.

(Sorry I should have put that from the beginning)