### PR TITLE
Add Cloud Foundry Integration

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README2CF.md
+++ b/README2CF.md
@@ -1,0 +1,41 @@
+### why
+
+Silex, is a free and open source website builder in the cloud. Create websites directly in the browser without writing code. And it is suitable for professional designers to produce great websites without constraints. Silex is also known as the HTML5 editor.And we want to leverage the Cloud Foundry to host our own site of Silex, so you are here ! ;)
+
+### Prerequisite
+You need to have an Cloud Foundry account, whatever Bluemix or PCF, both are the instance of Cloud Foundry Stack. For detail about them , pls referral to the link below and what you need to know is the follwing commands
+
+* `cf login`
+* `cf push`
+* `cf set env`
+* `cf start`
+* (Optional) Activate github service you need to define the env vars *`GITHUB_CLIENT_ID`* and *`GITHUB_CLIENT_SECRET`* ([Create a github app here](https://github.com/settings/applications/new))
+
+### Host an instance of Silex in Cloud Foundry
+
+1. Launch the "Git Shell"
+2. Clone this repository, and do not forget the sub modules (cloud-explorer and unifile)
+```
+$ git clone --recursive -b cf-integration https://github.com/yacloud-io/yadesigner.git
+```
+3. Go to Silex's Directory.
+```
+$ cd yadesigner
+```
+4. Login to the Bluemix
+
+```
+$ cf login -a api.ng.bluemix.net -u <you username here>
+and input the password in the interactive Shell
+
+$ cf push -m 512m <your add name here> --no-start
+$ wait...
+$ ...
+$ cf set-env <your add name here> GITHUB_CLIENT_ID <GITHUB_CLIENT_ID value here>
+$ cf set-env <your add name here> GITHUB_CLIENT_SECRET <GITHUB_CLIENT_SECRET value here>
+$ cf start <your add name here>
+```
+After deploy you could vist your own silex site
+
+### Links
+* [Bluemix official website](https://www.ng.bluemix.net)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "pm2 start .pm2.json",
     "start:debug": "SILEX_DEBUG=true node dist/server/server.js",
-    "build": "npm run build:css && npm run build:html && npm run build:js:release ",
+    "build": "npm run build:css && npm run build:html",
     "build:css": "node_modules/.bin/lessc src/css/_styles.less dist/client/css/admin.css --source-map",
     "build:html": "node_modules/.bin/jade src/html/index.jade --out dist/client/ --no-debug",
     "build:js:release": "java -jar node_modules/superstartup-closure-compiler/build/es6compiler.jar --js submodules/closure-library/closure/goog/ --js src/js/ --externs src/externs.js --js_output_file dist/client/js/admin.js --compilation_level ADVANCED_OPTIMIZATIONS --warning_level=VERBOSE --language_in ECMASCRIPT6_STRICT --language_out ECMASCRIPT3 --create_source_map dist/client/js/admin.js.map --closure_entry_point silex.App --only_closure_dependencies --manage_closure_dependencies --define=\"goog.DEBUG=false\"",


### PR DESCRIPTION
Add an option to host your own Silex site in [Bluemix](https://www.ng.bluemix.net), as for now , Bluemix or CloudFoundry only support one runtime in one app, so we need to update the build phase not using java but only using nodejs to build the assets. And the PR only illustrate publishing the site to Bluemix, it will handle all app related staff, building & running & monitoring...