### PR TITLE
hotfix for #755 (publication in case of a site with "broken" HTML

### DIFF
--- a/dist/server/Constants.json
+++ b/dist/server/Constants.json
@@ -1,5 +1,4 @@
 {
-  "JSON_STYLE_TAG_CLASS_NAME": "silex-json-styles",
   "EDITABLE_CLASS_NAME": "editable-style",
   "SILEX_CURRENT_PAGE_ID": "current-page-style",
   "SILEX_TEMP_TAGS_CSS_CLASS": "silex-temp-tag",

--- a/dist/server/DomPublisher.js
+++ b/dist/server/DomPublisher.js
@@ -103,20 +103,28 @@ module.exports = class DomPublisher {
     // all scripts, styles and assets from head => local
     const actions = [];
     DomTools.transformPaths(this.dom, (path, el, isInHead) => {
+      // el may be null if the path comes from the JSON object holding Silex data
+      // This is never supposed to happen because the tag holding the JSON object
+      // is removed from the head tag in DomPublisher::cleanup.
+      // But sometimes it appears that the tags are in the body
+      // Maybe we should change cleanup to look for the tagsToRemove also in the body?
+      const tagName = el ? el.tagName : null;
+
       const url = new URL(path, baseUrl);
+
       if(this.isDownloadable(url)) {
         const fileName = Path.basename(url.pathname);
-        const destFolder = this.getDestFolder(Path.extname(url.pathname), el.tagName);
+        const destFolder = this.getDestFolder(Path.extname(url.pathname), tagName);
         if(destFolder) {
           const destPath = `${destFolder}/${fileName}`;
           actions.push({
             original: path,
             srcPath: url.href,
             destPath: destPath,
-            tagName: el.tagName,
+            tagName: tagName,
             displayName: fileName,
           });
-          if(el.tagName) {
+          if(tagName) {
             // not an URL from a style sheet
             return destPath;
           }

--- a/dist/server/DomTools.js
+++ b/dist/server/DomTools.js
@@ -67,6 +67,10 @@ module.exports = class DomTools {
 
   /**
    * if value conatains `url('...')` this will be "transformed" by the provided function `fn`
+   * @param {string} value, e.g. "transparent" or "100px" or "url('image/photo%20page%20accueil.png')"
+   * @param {?CSSStyleSheet} stylesheet or null if the value comes from the JSON object holding silex data
+   * @param {boolean} isInHead, true if the stylesheet is in the head tag
+   * @param {function} fn
    */
   static transformValueUrlKeyword(value, stylesheet, isInHead, fn) {
     if(typeof value === 'string' && value.indexOf('url(') === 0) {
@@ -112,7 +116,7 @@ module.exports = class DomTools {
           const elementData = dataObj[elementId];
           for(let propName in elementData) {
             const propValue = elementData[propName];
-            const valueUrlKeyword = DomTools.transformValueUrlKeyword(propValue, null, null, fn);
+            const valueUrlKeyword = DomTools.transformValueUrlKeyword(propValue, null, true, fn);
             if(valueUrlKeyword) {
               elementData[propName] = valueUrlKeyword;
             }


### PR DESCRIPTION
fix publication for url() css keyword in the JSON object holding silex data, fixes #755
this happens when the tag holding the JSON is in the BODY instead of head 