### PR TITLE
Setting-dialog: a missing semicolon

### DIFF
--- a/src/js/view/dialog/settings-dialog.js
+++ b/src/js/view/dialog/settings-dialog.js
@@ -404,7 +404,7 @@ class SettingsDialog {
         <link href="${ font.href }" rel="stylesheet">
         <style>
           body {
-            width: 100%
+            width: 100%;
             font-family: ${ font.family };
             color: white;
             text-overflow: ellipsis;


### PR DESCRIPTION
Fonts setting the fonts examples has not set the font family 
Cause a missing semicolon
That fix this error.