### PR TITLE
Sticky top section in the Style Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .idea/
 .temp
 .cache
+package-lock.json
 node_modules
 *.log
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.sublime-project
 *.sublime-workspace
 *.DS_Store
+.idea/
 .temp
 .cache
 node_modules

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@silexlabs/grapesjs-filter-styles": "^1.0.0",
     "@silexlabs/grapesjs-fonts": "^1.0.18",
     "@silexlabs/grapesjs-loading": "1.0.9",
+    "@silexlabs/grapesjs-notifications": "^0.0.7",
     "@silexlabs/grapesjs-storage-rate-limit": "^1.0.8",
     "@silexlabs/grapesjs-symbols": "1.0.39",
     "@silexlabs/grapesjs-ui-suggest-classes": "1.0.23",

--- a/src/css/_variables.scss
+++ b/src/css/_variables.scss
@@ -3,7 +3,7 @@
 $primaryColor: #333333;
 $secondaryColor: #ddd;
 $tertiaryColor: #8873FE;
-$quaternaryColor: #A291FF;;
+$quaternaryColor: #A291FF;
 $darkerPrimaryColor: #292929;
 $lighterPrimaryColor: #575757;
 

--- a/src/css/grapesjs-plugins.scss
+++ b/src/css/grapesjs-plugins.scss
@@ -32,3 +32,12 @@
   @include square-borders-before;
   border-right-color: $secondaryColor;
 }
+
+// Adapting the layout of the suggestion list
+.gjs-suggest {
+  max-height: 30vh;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  padding-top: 7px;
+  border-bottom: solid $primaryColor 7px;
+}

--- a/src/css/grapesjs-plugins.scss
+++ b/src/css/grapesjs-plugins.scss
@@ -40,4 +40,28 @@
   overflow-x: hidden;
   padding-top: 7px;
   border-bottom: solid $primaryColor 7px;
+
+// grapesjs-notifications
+.gjs-editor .gjs-notification {
+  max-height: initial;
+  text-align: left;
+}
+.gjs-editor .gjs-notification,
+.gjs-editor .gjs-notification .gjs-sm-header,
+.gjs-editor .gjs-notification .gjs-notification__item,
+.gjs-editor .gjs-notification .gjs-notification__group > details,
+.gjs-editor .gjs-notification .gjs-notification__group > details > ul,
+.gjs-editor .gjs-notification .gjs-notification__group > details > summary,
+.gjs-editor .gjs-notification .gjs-notification__group {
+  padding: 0;
+  margin: 0;
+}
+.gjs-editor .gjs-notification .gjs-notification__group,
+.gjs-editor .gjs-notification .gjs-notification__item {
+  margin: 10px 0;
+  padding: 10px 0;
+}
+
+.gjs-editor .gjs-notification .gjs-notification__group .gjs-notification__item {
+  margin-left: 10px;
 }

--- a/src/css/grapesjs.scss
+++ b/src/css/grapesjs.scss
@@ -92,9 +92,9 @@
 
 // Sticky CSS tags section
 
-.gjs-pn-views-container > div > div:first-child > div:first-child {
+.top-style-section {
   position: sticky;
-  top: 0;
+  top: -1px; /* Fixes a visual gap on the top */
   border-bottom: solid $lighterPrimaryColor 1px;
   background-color: $primaryColor;
   box-shadow: 0 0 15px 0 #00000060;
@@ -126,16 +126,6 @@
 
 #gjs-clm-up {
   margin-top: 0;
-}
-
-// Adapting the layout of the suggestion list
-
-.gjs-suggest {
-  max-height: 30vh;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  padding-top: 7px;
-  border-bottom: solid $primaryColor 7px;
 }
 
 /*

--- a/src/css/grapesjs.scss
+++ b/src/css/grapesjs.scss
@@ -90,6 +90,44 @@
   right: var(--viewsPanelWidth);
 }
 
+// Sticky CSS tags section
+
+.gjs-pn-views-container > div > div:first-child > div:first-child {
+  position: sticky;
+  top: 0;
+  border-bottom: solid $lighterPrimaryColor 1px;
+  background-color: $primaryColor;
+  box-shadow: 0 0 15px 0 #00000060;
+  z-index: 999;
+}
+
+.gjs-clm-label-sel {
+  opacity: 0.5;
+}
+
+.gjs-clm-sels-info {
+  padding: 7px 0;
+  margin: 0;
+  overflow-x: scroll;
+}
+
+.gjs-clm-sel-rule {
+  word-break: break-all;
+}
+
+#gjs-clm-tags-field.gjs-field {
+  margin: 0;
+}
+
+.gjs-clm-tags {
+  padding-top: 7px;
+  padding-bottom: 0;
+}
+
+#gjs-clm-up {
+  margin-top: 0;
+}
+
 /*
 */
 // Font awesome 5 fix

--- a/src/css/grapesjs.scss
+++ b/src/css/grapesjs.scss
@@ -128,6 +128,16 @@
   margin-top: 0;
 }
 
+// Adapting the layout of the suggestion list
+
+.gjs-suggest {
+  max-height: 30vh;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  padding-top: 7px;
+  border-bottom: solid $primaryColor 7px;
+}
+
 /*
 */
 // Font awesome 5 fix

--- a/src/css/project-bar.scss
+++ b/src/css/project-bar.scss
@@ -30,7 +30,11 @@
         background-color: $lighterPrimaryColor;
         width: $projectBarWidth;
         box-shadow: none;
-     }
+      }
+    }
+    .#{$pn-prefix}btn.project-bar__dirty {
+      background-color: $quaternaryColor;
+      color: white;
     }
   }
   .logo {
@@ -85,13 +89,7 @@
       }
       .project-bar__panel-header-button {
         cursor: pointer;
-        font-size: large;
-        font-weight: 400;
         span {
-          position: relative;
-          left: -2px;
-          top: -11px;
-          font-weight: bolder;
           background-color: #444;
           border-radius: 100%;
           display: inline-block;

--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -363,6 +363,9 @@ export async function initEditor(config: EditorConfig) {
       // use the style filter plugin
       editor.StyleManager.addProperty('extra', { extend: 'filter' })
 
+      // Add a class to the Style Manager's sticky top section
+      editor.SelectorManager.selectorTags.el.parentElement.classList.add("top-style-section")
+
       // GrapesJs editor is ready
       resolve(editor)
     })

--- a/src/ts/client/grapesjs/project-bar.ts
+++ b/src/ts/client/grapesjs/project-bar.ts
@@ -18,8 +18,8 @@
 import { Editor, Panel } from 'grapesjs'
 import {html, render} from 'lit-html'
 
-const panelId = 'project-bar-panel'
-const containerPanelId = 'project-bar-container'
+export const PROJECT_BAR_PANEL_ID = 'project-bar-panel'
+export const containerPanelId = 'project-bar-container'
 
 export interface PanelObject {
   command: string | ((editor: Editor) => void)
@@ -34,6 +34,7 @@ export interface PanelObject {
     text: string
     className: string
   }[]
+  onClick?: (editor: Editor) => void
 }
 
 export const projectBarPlugin = (editor, opts) => {
@@ -44,7 +45,7 @@ export const projectBarPlugin = (editor, opts) => {
   })
   // create the project bar panel in grapesjs
   editor.Panels.addPanel({
-    id: panelId,
+    id: PROJECT_BAR_PANEL_ID,
     buttons: opts.panels,
     visible  : true,
   })
@@ -113,6 +114,10 @@ export function addButton(editor: Editor, panel: PanelObject) {
         document.body.classList.add('silex-squeeze-left')
         editor.refresh()
       }
+      // Call the onClick function if it exists
+      if(panel.onClick) panel.onClick(editor)
+      // Remove the dirty flag
+      el.classList.remove('project-bar__dirty')
     },
     stop() {
       if(panel.attributes.containerClassName) {
@@ -121,6 +126,10 @@ export function addButton(editor: Editor, panel: PanelObject) {
         document.body.classList.remove('silex-squeeze-left')
         editor.refresh()
       }
+      // Call the onClick function if it exists
+      if(panel.onClick) panel.onClick(editor)
+      // Remove the dirty flag
+      el.classList.remove('project-bar__dirty')
     },
   })
 }


### PR DESCRIPTION
This contribution makes the top section of the Style Manager sticky, so that it stays visible when scrolling. It also comes with minor layout adjustments in this section, in order to welcome this new addition.

![firefox_lFKTN608aZ](https://github.com/silexlabs/Silex/assets/44942598/df834c29-a67f-4f35-9939-030852a45c3c)
