### PR TITLE
fix: exit with error code if package build fails

### DIFF
--- a/scripts/build-packages.js
+++ b/scripts/build-packages.js
@@ -68,7 +68,7 @@ function buildPackage(packageName) {
     console.log(`✅ ${packageName} built successfully`);
   } catch (error) {
     console.error(`❌ Failed to build ${packageName}:`, error.message);
-    // Don't exit - continue with other packages
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
The `build-packages.js` script currently continues building subsequent packages if one fails, which can lead to cascading errors because downstream packages depend on successfully built upstream packages. This change ensures that if a package's build script fails, the entire process terminates immediately with a non-zero exit code. This prevents broken builds from being reported as successful and simplifies troubleshooting by stopping the build process as soon as a failure is encountered.