### PR TITLE
ci(caprover): checkout submodules non-recursively (restore meta-repo behavior)

### DIFF
--- a/.github/workflows/caprover.yml
+++ b/.github/workflows/caprover.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true  # not recursive: silex-dashboard's nested SSH submodule (dashboard-silexv3) isn't CI-cloneable and isn't needed to build the Dockerfile (meta-repo used true too)
       - name: Deploy to CapRover (canary)
         uses: caprover/deploy-from-github@v1.1.2
         with:
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true  # not recursive: silex-dashboard's nested SSH submodule (dashboard-silexv3) isn't CI-cloneable and isn't needed to build the Dockerfile (meta-repo used true too)
       - name: Deploy to CapRover (production)
         uses: caprover/deploy-from-github@v1.1.2
         with:


### PR DESCRIPTION
Restore the meta-repo behavior for the CapRover deploy checkout: `submodules: recursive` → `submodules: true`.
