### PR TITLE
docs: add Silex Desktop bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/desktop-bug.md
+++ b/.github/ISSUE_TEMPLATE/desktop-bug.md
@@ -1,0 +1,11 @@
+---
+name: Silex Desktop bug
+about: Report a problem with the Silex Desktop app
+title: "[Desktop] "
+labels: desktop
+---
+
+OS and version: (e.g. Windows 11 / macOS 14 / Ubuntu 24.04)
+Silex Desktop version:
+
+What happened:


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/desktop-bug.md` so Desktop beta testers can file bugs with a consistent, minimal format (OS + version + free-text; `desktop` label applied automatically).

Clean re-creation on the new monorepo `main` — supersedes #1749, whose branch was based on the old meta-repo history and showed the full divergence (62 files / 100+ commits) after the default branch switched to the monorepo.