### PR TITLE
docs: NLnet funding acknowledgement + monorepo migration onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ Silex stands on the shoulders of these open-source projects and their communitie
 - [Tauri](https://tauri.app/) — desktop app framework (Rust + WebView)
 - [TypeScript](https://www.typescriptlang.org/) — language used across packages
 
+## Funding
+
+An [OW2 project](https://projects.ow2.org/view/silex/), funded by the [NGI0 Commons Fund](https://www.silex.me/nlnet), supported by its [sponsors and volunteers](https://opencollective.com/silex).
+
 ## Credits
 
 Brought to you since 2009 by [Alex Hoyau](https://lexoyo.me) and the Silex community.


### PR DESCRIPTION
## Credit NLnet funding

Adds an evergreen **Funding** section to the README and a `FUNDING.yml`, crediting the NLnet grant
behind Silex's work — including this monorepo consolidation.

The monorepo is **one step of the "move to libre forge" workstream** — one of the five workstreams of
Silex's NLnet-funded project (NGI0 Commons Fund, project 2025-10-133): the desktop app, editor
internationalization, moving off GitHub to a libre forge, a libre package registry, and libre fonts.
Details and progress: **https://www.silex.me/nlnet** — tracked under the
[`nlnet`](https://github.com/silexlabs/Silex/labels/nlnet) label.

### What's in this PR
- `.github/FUNDING.yml` — Open Collective sponsor link.
- `README.md` — a **Funding** section pointing to silex.me/nlnet.

### The migration itself
The monorepo consolidation landed on `main` via a branch replacement that **preserved the full history
and every contributor's authorship** (6507 commits). The old meta-repo `main` is preserved as the
branch `legacy-main` and the tag `pre-monorepo`.

Contributor guide (update a local clone, port in-flight work):
**https://docs.silex.me/en/developer/migrating-from-the-old-repos/** (EN + FR).

Funded-by: NLnet Foundation, NGI0 Commons Fund (project 2025-10-133)
