### PR TITLE
chore: add FUNDING.yml (Open Collective sponsor button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: silex


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the repo shows a Sponsor button linking to the project's Open Collective (https://opencollective.com/silex).