### PR TITLE
ci(caprover): fix deploy tar (bundle submodules) + simplify release flow

### DIFF
--- a/.github/workflows/caprover.yml
+++ b/.github/workflows/caprover.yml
@@ -37,7 +37,7 @@ jobs:
 
   production:
     name: deploy production
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'canary') && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/caprover.yml
+++ b/.github/workflows/caprover.yml
@@ -1,7 +1,7 @@
 name: Deploy to CapRover
 
 # Deploys the server (root Dockerfile, referenced by the root captain-definition)
-# to CapRover: tar the tracked files (git archive) and upload via the caprover CLI.
+# to CapRover: tar the tracked files (incl. submodule content) and upload via the caprover CLI.
 #
 # Required secrets:
 #   CAPROVER_SERVER        e.g. https://captain.your-domain.com
@@ -22,13 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true  # not recursive: silex-dashboard's nested SSH submodule (dashboard-silexv3) isn't CI-cloneable and isn't needed to build the Dockerfile (meta-repo used true too)
-      # Direct caprover CLI (the deploy-from-github action passes the tar as a
-      # positional arg, which caprover CLI 2.x rejects). We tar the tracked files
-      # ourselves (captain-definition + Dockerfile + source) and upload with --tarFile.
+          submodules: true  # the SaaS serves silex-dashboard/_site
       - name: Deploy to CapRover (canary)
         run: |
-          git archive --format=tar -o deploy.tar HEAD
+          git ls-files --recurse-submodules -z | tar --null --no-recursion -cf deploy.tar -T -
           npx -y caprover@2.3.1 deploy \
             --caproverUrl "${{ secrets.CAPROVER_SERVER }}" \
             --appName "${{ secrets.CAPROVER_APP_CANARY }}" \
@@ -43,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true  # not recursive: silex-dashboard's nested SSH submodule (dashboard-silexv3) isn't CI-cloneable and isn't needed to build the Dockerfile (meta-repo used true too)
+          submodules: true  # the SaaS serves silex-dashboard/_site
       - name: Deploy to CapRover (production)
         run: |
-          git archive --format=tar -o deploy.tar HEAD
+          git ls-files --recurse-submodules -z | tar --null --no-recursion -cf deploy.tar -T -
           npx -y caprover@2.3.1 deploy \
             --caproverUrl "${{ secrets.CAPROVER_SERVER }}" \
             --appName "${{ secrets.CAPROVER_APP_PROD }}" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,18 +29,10 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Compute tags
+      - name: Compute version
         id: tags
         shell: bash
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          # Moving tag: prereleases (canary/alpha/beta) must NOT advance `latest`.
-          if [[ "$VERSION" == *-* ]]; then
-            echo "moving=prerelease" >> "$GITHUB_OUTPUT"
-          else
-            echo "moving=latest" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -52,4 +44,4 @@ jobs:
           push: true
           tags: |
             silexlabs/silex-platform:${{ steps.tags.outputs.version }}
-            silexlabs/silex-platform:${{ steps.tags.outputs.moving }}
+            silexlabs/silex-platform:latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,11 @@ We use a trunk-based model: `main` is the single, always-releasable branch.
 - `main` is protected — no direct pushes. All work lands via PR.
 - Use short-lived branches (`feat/...`, `fix/...`) and open a PR against `main`.
 - PRs are **squash-merged**; the squash title must follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`), since it drives the changelog.
-- Unreleased work can live on `main` safely: only tagged commits are deployed (see below), so nothing ships until you tag it.
+- `main` is deployed continuously to **canary** ([canary.silex.me](https://canary.silex.me)) for preview; **production** ships only when you tag, so nothing reaches production until you tag it.
 
-Releases are driven by git tags, in **two independent channels** (a server release never ships a desktop update, and vice-versa):
+Production releases are driven by git tags, in **two independent channels** (a server release never ships a desktop update, and vice-versa):
 
-- **`v*`** (e.g. `v3.8.1`) — server/web: publishes the `silexlabs/silex-platform` Docker image and deploys to CapRover (production on stable `v*`, canary on `main` pushes; a tag counts as prerelease only if it contains `-canary`, `-alpha` or `-beta`).
+- **`v*`** (e.g. `v3.8.1`) — server/web: publishes the `silexlabs/silex-platform` Docker image and deploys to CapRover production ([v3.silex.me](https://v3.silex.me)).
 - **`desktop-v*`** (e.g. `desktop-v1.2.0`) — desktop: builds the Tauri apps (macOS/Windows/Linux) and publishes the GitHub release with auto-updater metadata.
 
 Releases are cut by maintainers by tagging `main`.

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Before pushing: `pnpm lint` and `pnpm test` (and `cargo test -p silex-server` fo
 
 ### Releasing
 
-Releases are driven by git tags, in **two independent channels** (a server release never ships a desktop update, and vice-versa):
+`main` is deployed continuously to **canary** ([canary.silex.me](https://canary.silex.me)). Production releases are driven by git tags, in **two independent channels** (a server release never ships a desktop update, and vice-versa):
 
-- **`v*`** (e.g. `v3.8.1`) — server/web release: publishes the `silexlabs/silex-platform` Docker image and deploys to CapRover (canary on `main` pushes, production on stable tags; a tag is treated as prerelease only if it contains `-canary`, `-alpha` or `-beta`).
+- **`v*`** (e.g. `v3.8.1`) — server/web release: publishes the `silexlabs/silex-platform` Docker image and deploys to CapRover production ([v3.silex.me](https://v3.silex.me)).
 - **`desktop-v*`** (e.g. `desktop-v1.2.0`) — desktop release: builds the Tauri apps (macOS, Windows, Linux) and publishes the GitHub release with auto-updater metadata.
 
 ## AI / Vibe coding


### PR DESCRIPTION
Two changes to the CapRover release pipeline.

## Fix: deploy tar was missing the dashboard submodule

`git archive HEAD` only tars the superproject and drops submodule content, so the SaaS dashboard (served from `silex-dashboard/_site` by `server/deploy/server-plugins/dashboard.js`) was missing from the deployed image. Tar via `git ls-files --recurse-submodules` instead, which walks the checked-out submodules. Regression from the earlier switch to the caprover CLI. Tested against the v3beta app: `v3beta.silex.me/` now serves the dashboard (200) again.

## Simplify the server release flow

Drop the server prerelease concept (it built a Docker image but deployed nowhere, which was confusing).

- caprover.yml: any `v*` tag deploys to production (was: stable-only, with a prerelease exclusion that deployed nowhere)
- docker.yml: `v*` tags push the image + `latest` (dropped the prerelease "moving tag" logic)
- README + CONTRIBUTING: document the clean model: `main` deploys continuously to canary, `v*` tag deploys to production, `desktop-v*` for the desktop release

Desktop prereleases (`desktop-v*-beta`) are unchanged.