### PR TITLE
ci(desktop): build linux-only on PRs, full matrix on release tags

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,16 +1,7 @@
 name: Desktop release
 
-# Builds the Silex Desktop (Tauri) app and publishes its GitHub release + updater feed.
-# Desktop has its own version line, released on demand via `desktop-v*` tags — so a
-# server release (v*) never ships a desktop update. GitHub Releases are desktop-only,
-# so the updater endpoint (releases/latest/download/latest.json) always resolves to the
-# latest published desktop release.
-#   push main / PR → unsigned build (CI smoke test)
-#   tag desktop-v* → signed build + draft GitHub release (publish it to ship the update)
-
 on:
   push:
-    branches: [main]
     tags: ['desktop-v*']
   pull_request:
     branches: [main]
@@ -19,22 +10,30 @@ permissions:
   contents: write
 
 jobs:
+  # Linux-only on PRs (Rust+TS is shared, so linux catches almost all breakage);
+  # full 4-platform matrix only on desktop-v* tags, where the costly macOS/Windows
+  # runners are worth it. No per-commit main build — the PR already covered it.
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+    steps:
+      - id: m
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/desktop-v* ]]; then
+            echo 'matrix={"include":[{"platform":"linux","os":"ubuntu-latest"},{"platform":"macos-arm","os":"macos-latest"},{"platform":"macos-x64","os":"macos-latest","rust-target":"x86_64-apple-darwin"},{"platform":"windows","os":"windows-latest"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"platform":"linux","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: set-matrix
     name: build (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
-      matrix:
-        include:
-          - platform: linux
-            os: ubuntu-latest
-          - platform: macos-arm
-            os: macos-latest
-          - platform: macos-x64
-            os: macos-latest
-            rust-target: x86_64-apple-darwin
-          - platform: windows
-            os: windows-latest
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
 
     steps:
       # Prevent CRLF conversion on Windows (eslint requires LF)


### PR DESCRIPTION
The desktop Tauri build is heavy — 4 platforms including 2 macOS runners (~10x Linux cost) and a full Rust+Tauri compile. It was triggered on every push to `main` **and** every PR.

Two wasteful parts:

- **Build on push to `main` is redundant.** `main` is protected, so every change lands via a PR that already smoke-tested the desktop build. Re-running the whole matrix per main commit produced nothing new.
- **Full 4-platform matrix on every PR is overkill.** The Rust+TS code is shared across platforms, so a linux build catches almost all breakage (compile errors, frontend build failures, missing deps). macOS/Windows specifics are rare and are validated at release time anyway.

## Change

- Drop the `push: branches: [main]` trigger.
- Compute the matrix dynamically: **PR → linux only**, **`desktop-v*` tag → full 4 platforms** (linux, macos-arm, macos-x64, windows).
- The signed build + release path (`desktop-v*` tags) is unchanged.

## Effect

- A typical PR runs **1 linux build** instead of 4 (dropping the 2 expensive macOS runners).
- **No desktop build per main commit.**
- Cross-platform validation still happens where it counts: the release tag.

Desktop isn't a required check (the required ones are `build / lint / test` + `rust`), so the lighter PR matrix doesn't affect merge gating.