### PR TITLE
chore(plugins): modernize tsconfigs (drop deprecated es5/node10)

### DIFF
--- a/grapesjs-plugins/grapesjs-ai-capabilities/tsconfig.json
+++ b/grapesjs-plugins/grapesjs-ai-capabilities/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": [
       "dom",
       "dom.iterable",
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,

--- a/grapesjs-plugins/grapesjs-filter-styles/tsconfig.json
+++ b/grapesjs-plugins/grapesjs-filter-styles/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": [
       "dom",
       "dom.iterable",
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false

--- a/grapesjs-plugins/grapesjs-fonts/tsconfig.json
+++ b/grapesjs-plugins/grapesjs-fonts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": [
       "dom",
       "dom.iterable",
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,

--- a/grapesjs-plugins/grapesjs-notifications/src/NotificationManager.ts
+++ b/grapesjs-plugins/grapesjs-notifications/src/NotificationManager.ts
@@ -1,6 +1,6 @@
 import { Editor } from "grapesjs"
 import { Notification, NotificationOptions as BaseNotificationOptions } from "./Notification"
-import { StyleInfo } from "lit/directives/style-map"
+import { StyleInfo } from "lit/directives/style-map.js"
 
 export interface NotificationOptions extends BaseNotificationOptions {
   id?: string

--- a/grapesjs-plugins/grapesjs-notifications/tsconfig.json
+++ b/grapesjs-plugins/grapesjs-notifications/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": [
       "dom",
       "dom.iterable",
@@ -15,12 +15,13 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,
+    "rootDir": "./src",
     "outDir": "dist"
   },
   "include": [

--- a/grapesjs-plugins/grapesjs-version-flow/tsconfig.json
+++ b/grapesjs-plugins/grapesjs-version-flow/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": [
       "dom",
       "dom.iterable",
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false


### PR DESCRIPTION
Clear the TS5107 deprecation (`target: es5` / `moduleResolution: node10`) on 5 plugins before it becomes a hard error in TS 7.0.

- `target` es5 -> es2019, `moduleResolution` node -> bundler (ai-capabilities, filter-styles, fonts, notifications, version-flow)
- notifications: + explicit `rootDir`, + `.js` on the lit subpath import (bundler honors lit's exports map)

Validated: `build:plugins` green, 0 TS5107, no new TS errors.