### PR TITLE
chore(security): bump pnpm 9.15.9 → 10.34.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,5 +187,5 @@
     "webpack": "5.108.2",
     "webpack-cli": "7.1.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.4"
 }


### PR DESCRIPTION
Bump pnpm 9.15.9 → 10.34.4 (9 high advisories affect <10.34.x); lockfile unchanged, build/lint/test green. Closes #1766