### PR TITLE
fix(desktop): send real version, anon install id, channel and os/arch to GlitchTip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -34,6 +34,9 @@ open = "5"
 # Platform-specific directories (for telemetry consent before Tauri init)
 dirs = "6"
 
+# Anonymous install id (persistent UUID for telemetry user count)
+uuid = { version = "1", features = ["v4"] }
+
 # Error tracking / telemetry (GlitchTip / Sentry-compatible)
 sentry = { version = "0.35", features = ["tracing"] }
 

--- a/desktop/src-tauri/scripts/desktop-bridge.js
+++ b/desktop/src-tauri/scripts/desktop-bridge.js
@@ -6,27 +6,38 @@
   const { listen } = window.__TAURI__.event;
 
   // Frontend error tracking (GlitchTip / Sentry-compatible).
-  // DSN is read from the same GLITCHTIP_DSN env var via a Tauri command.
-  invoke('get_glitchtip_dsn').then((dsn) => {
-    if (!dsn) return;
+  // Real version, channel, anonymous install id and OS/arch come from Rust so the
+  // webview reports the same identity as the native side (not a hardcoded 0.1.0).
+  invoke('get_telemetry_context').then((ctx) => {
+    if (!ctx?.dsn) return;
     const script = document.createElement('script');
     script.src = 'https://browser.sentry-cdn.com/8.46.0/bundle.tracing.min.js';
     script.crossOrigin = 'anonymous';
     script.onload = () => {
-      if (window.Sentry) {
-        window.Sentry.init({
-          dsn,
-          release: '0.1.0',
-          environment: 'production',
-          tracesSampleRate: 1.0,
-          integrations: [window.Sentry.browserTracingIntegration()],
-        });
-        window.Sentry.setTag('os', navigator.platform);
-        window.Sentry.setTag('context', 'webview');
-      }
+      if (!window.Sentry) return;
+      window.Sentry.init({
+        dsn: ctx.dsn,
+        release: ctx.release,
+        environment: ctx.environment,
+        tracesSampleRate: 1.0,
+        integrations: [window.Sentry.browserTracingIntegration()],
+      });
+      window.Sentry.setUser({ id: ctx.user_id });
+      window.Sentry.setTag('os', ctx.os);
+      window.Sentry.setTag('arch', ctx.arch);
+      window.Sentry.setTag('context', 'webview');
     };
     document.head.appendChild(script);
-  }).catch(() => { /* GLITCHTIP_DSN not set — telemetry disabled */ });
+  }).catch(() => { /* no consent / DSN not set — telemetry disabled */ });
+
+  // Wrap listen() so a rejected Tauri IPC (plugin:event|listen) becomes a breadcrumb +
+  // handled capture with a culprit, instead of an UnhandledRejection with an empty one.
+  const safeListen = (event, handler) => {
+    window.Sentry?.addBreadcrumb?.({ category: 'tauri', message: `listen ${event}`, level: 'info' });
+    return listen(event, handler).catch((err) => {
+      window.Sentry?.captureException?.(err, { tags: { tauri_command: `plugin:event|listen:${event}` } });
+    });
+  };
 
   const TEXT_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'li', 'td', 'th', 'label', 'blockquote'];
 
@@ -314,9 +325,9 @@
     });
 
     // Listen for menu events from Tauri (triggered by MCP or quit dialog)
-    listen('menu-save', () => editor.store());
-    listen('menu-undo', () => editor.UndoManager.undo());
-    listen('menu-redo', () => editor.UndoManager.redo());
-    listen('menu-close-project', () => { window.location.href = '/'; });
+    safeListen('menu-save', () => editor.store());
+    safeListen('menu-undo', () => editor.UndoManager.undo());
+    safeListen('menu-redo', () => editor.UndoManager.redo());
+    safeListen('menu-close-project', () => { window.location.href = '/'; });
   });
 })();

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -146,15 +146,64 @@ fn log_debug(message: String) {
     tracing::debug!("[webview] {message}");
 }
 
-#[tauri::command]
-fn get_glitchtip_dsn() -> Option<String> {
-    // Only expose DSN to the frontend if the user has opted in
-    let data_dir = dirs::data_dir()?.join("org.silex.desktop");
-    if read_telemetry_consent(&data_dir) == Some(true) {
-        option_env!("GLITCHTIP_DSN").map(String::from)
+/// Map a release version to a GlitchTip environment channel (canary/alpha/beta/stable).
+fn telemetry_environment(version: &str) -> &'static str {
+    if cfg!(debug_assertions) {
+        "development"
+    } else if version.contains("canary") {
+        "canary"
+    } else if version.contains("alpha") {
+        "alpha"
+    } else if version.contains("beta") {
+        "beta"
     } else {
-        None
+        "stable"
     }
+}
+
+/// Persistent anonymous install id (UUID v4), generated on first launch. No PII.
+fn get_or_create_install_id(data_dir: &PathBuf) -> String {
+    let path = data_dir.join("install_id");
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let existing = existing.trim();
+        if !existing.is_empty() {
+            return existing.to_string();
+        }
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    let _ = std::fs::create_dir_all(data_dir);
+    let _ = std::fs::write(&path, &id);
+    id
+}
+
+/// Telemetry config handed to the frontend Sentry init (real version, channel, install id, OS).
+#[derive(serde::Serialize)]
+struct TelemetryContext {
+    dsn: String,
+    release: String,
+    environment: String,
+    user_id: String,
+    os: String,
+    arch: String,
+}
+
+#[tauri::command]
+fn get_telemetry_context(app: tauri::AppHandle) -> Option<TelemetryContext> {
+    // Only expose telemetry config to the frontend if the user has opted in
+    let data_dir = dirs::data_dir()?.join("org.silex.desktop");
+    if read_telemetry_consent(&data_dir) != Some(true) {
+        return None;
+    }
+    let dsn = option_env!("GLITCHTIP_DSN")?.to_string();
+    let version = app.package_info().version.to_string();
+    Some(TelemetryContext {
+        dsn,
+        release: version.clone(),
+        environment: telemetry_environment(&version).to_string(),
+        user_id: get_or_create_install_id(&data_dir),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+    })
 }
 
 fn show_quit_dialog(app: &tauri::AppHandle) {
@@ -303,6 +352,13 @@ fn main() {
         .join("org.silex.desktop");
     let _ = std::fs::create_dir_all(&app_data_dir);
 
+    // Real app version comes from tauri.conf.json (patched from the tag in CI), not
+    // CARGO_PKG_VERSION (stuck at the 0.1.0 placeholder). The context is built once here
+    // and moved into .run() below.
+    let context = tauri::generate_context!();
+    let app_version = context.package_info().version.to_string();
+    let install_id = get_or_create_install_id(&app_data_dir);
+
     // Initialize error tracking (GlitchTip / Sentry-compatible).
     // Sentry is always initialized when GLITCHTIP_DSN is set, but events are only
     // sent if the user has opted in. This way consent takes effect immediately
@@ -312,10 +368,8 @@ fn main() {
     let _sentry_guard = sentry::init(sentry::ClientOptions {
         dsn: option_env!("GLITCHTIP_DSN")
             .and_then(|s| s.parse().ok()),
-        release: Some(env!("CARGO_PKG_VERSION").into()),
-        environment: Some(
-            if cfg!(debug_assertions) { "development" } else { "production" }.into(),
-        ),
+        release: Some(app_version.clone().into()),
+        environment: Some(telemetry_environment(&app_version).into()),
         before_send: Some(std::sync::Arc::new(move |event| {
             if read_telemetry_consent(&consent_dir_for_send) == Some(true) {
                 Some(event)
@@ -340,6 +394,11 @@ fn main() {
     sentry::configure_scope(|scope| {
         scope.set_tag("os", std::env::consts::OS);
         scope.set_tag("arch", std::env::consts::ARCH);
+        // Anonymous install id → distinguishes distinct installs from repeat crashes.
+        scope.set_user(Some(sentry::protocol::User {
+            id: Some(install_id.clone()),
+            ..Default::default()
+        }));
     });
 
     tracing_subscriber::registry()
@@ -362,7 +421,7 @@ fn main() {
             mark_unsaved,
             open_folder,
             log_debug,
-            get_glitchtip_dsn,
+            get_telemetry_context,
         ])
         .setup(|app| {
             // Log app launch with OS/arch info (visible in Issues even without errors)
@@ -471,6 +530,6 @@ fn main() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
+        .run(context)
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
Fixes GlitchTip under-instrumentation: real app version (was 0.1.0), persistent anonymous install id, canary/beta/stable environment, os/arch tags, and a breadcrumb+capture around plugin:event|listen. Closes #1754