### PR TITLE
feat(advanced-selector): add ::selection pseudo-element support (#1680)

### DIFF
--- a/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.test.ts
+++ b/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.test.ts
@@ -5,6 +5,13 @@ describe('PseudoClass', () => {
     expect(toString(PSEUDO_CLASSES.find(p => p.type === 'hover')!)).toBe(':hover')
     expect(toString(PSEUDO_CLASSES.find(p => p.type === 'nth-child')!)).toBe(':nth-child()')
   })
+  test('toString should use :: for pseudo-elements', () => {
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'before')!)).toBe('::before')
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'after')!)).toBe('::after')
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'first-line')!)).toBe('::first-line')
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'first-letter')!)).toBe('::first-letter')
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'selection')!)).toBe('::selection')
+  })
   test('fromString should return correct pseudo-class object', () => {
     expect(fromString(':hover')).toEqual(PSEUDO_CLASSES.find(p => p.type === 'hover'))
     expect(fromString(':nth-child()')).toEqual(PSEUDO_CLASSES.find(p => p.type === 'nth-child'))
@@ -12,6 +19,11 @@ describe('PseudoClass', () => {
       ...PSEUDO_CLASSES.find(p => p.type === 'nth-child'),
       param: '2n+1',
     })
+  })
+  test('fromString should parse both :: and : for pseudo-elements', () => {
+    expect(fromString('::selection')).toEqual(PSEUDO_CLASSES.find(p => p.type === 'selection'))
+    expect(fromString('::before')).toEqual(PSEUDO_CLASSES.find(p => p.type === 'before'))
+    expect(fromString(':before')).toEqual(PSEUDO_CLASSES.find(p => p.type === 'before'))
   })
   test('fromString should throw error if pseudo-class is invalid', () => {
     expect(() => fromString(':NOTVALID')).toThrow()

--- a/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.test.ts
+++ b/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.test.ts
@@ -5,11 +5,11 @@ describe('PseudoClass', () => {
     expect(toString(PSEUDO_CLASSES.find(p => p.type === 'hover')!)).toBe(':hover')
     expect(toString(PSEUDO_CLASSES.find(p => p.type === 'nth-child')!)).toBe(':nth-child()')
   })
-  test('toString should use :: for pseudo-elements', () => {
-    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'before')!)).toBe('::before')
-    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'after')!)).toBe('::after')
-    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'first-line')!)).toBe('::first-line')
-    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'first-letter')!)).toBe('::first-letter')
+  test('toString uses :: only for ::selection, single colon for legacy pseudo-elements', () => {
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'before')!)).toBe(':before')
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'after')!)).toBe(':after')
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'first-line')!)).toBe(':first-line')
+    expect(toString(PSEUDO_CLASSES.find(p => p.type === 'first-letter')!)).toBe(':first-letter')
     expect(toString(PSEUDO_CLASSES.find(p => p.type === 'selection')!)).toBe('::selection')
   })
   test('fromString should return correct pseudo-class object', () => {

--- a/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.ts
+++ b/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.ts
@@ -35,6 +35,7 @@ export enum PseudoClassType {
   AFTER = 'after',
   FIRST_LINE = 'first-line',
   FIRST_LETTER = 'first-letter',
+  SELECTION = 'selection',
 
   // Form states
   ENABLED = 'enabled',
@@ -60,6 +61,7 @@ export interface PseudoClass {
   type: PseudoClassType
   hasParam: boolean
   param?: string | null
+  isPseudoElement?: boolean
   sentencePre: string
   sentencePost?: string
   helpLink?: string
@@ -99,10 +101,11 @@ export const PSEUDO_CLASSES: PseudoClass[] = [
   { type: PseudoClassType.ROOT, hasParam: false, sentencePre: 'When it is the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:root' },
   { type: PseudoClassType.SCOPE, hasParam: false, sentencePre: 'When it is within', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:scope' },
   { type: PseudoClassType.TARGET, hasParam: false, sentencePre: 'When URL matches', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:target' },
-  { type: PseudoClassType.BEFORE, hasParam: false, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::before' },
-  { type: PseudoClassType.AFTER, hasParam: false, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::after' },
-  { type: PseudoClassType.FIRST_LINE, hasParam: false, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line' },
-  { type: PseudoClassType.FIRST_LETTER, hasParam: false, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter' },
+  { type: PseudoClassType.BEFORE, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::before' },
+  { type: PseudoClassType.AFTER, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::after' },
+  { type: PseudoClassType.FIRST_LINE, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line' },
+  { type: PseudoClassType.FIRST_LETTER, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter' },
+  { type: PseudoClassType.SELECTION, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::selection' },
 
   // Form states
   { type: PseudoClassType.ENABLED, hasParam: false, sentencePre: 'When it is', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:enabled' },
@@ -121,10 +124,11 @@ export const PSEUDO_CLASSES: PseudoClass[] = [
 // Functions
 
 export function toString(pseudoClass: PseudoClass): string {
+  const prefix = pseudoClass.isPseudoElement ? '::' : ':'
   if (pseudoClass.hasParam) {
-    return `:${pseudoClass.type}(${pseudoClass.param ?? ''})`
+    return `${prefix}${pseudoClass.type}(${pseudoClass.param ?? ''})`
   } else {
-    return `:${pseudoClass.type}`
+    return `${prefix}${pseudoClass.type}`
   }
 }
 
@@ -133,7 +137,7 @@ export function toString(pseudoClass: PseudoClass): string {
  * @example fromString(':nth-child(2n+1) // { type: 'nth-child', hasParam: true, param: '2n+1', sentencePre: 'When it is the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child' }
  */
 export function fromString(pseudoClassStr: string): PseudoClass {
-  const pseudoMatch = pseudoClassStr.match(/:([-\w]+)(\([^)]*\))?/)
+  const pseudoMatch = pseudoClassStr.match(/::?([-\w]+)(\([^)]*\))?/)
   if (!pseudoMatch) {
     throw new Error(`Invalid pseudo-class: ${pseudoClassStr}`)
   }

--- a/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.ts
+++ b/grapesjs-plugins/grapesjs-advanced-selector/src/model/PseudoClass.ts
@@ -101,10 +101,12 @@ export const PSEUDO_CLASSES: PseudoClass[] = [
   { type: PseudoClassType.ROOT, hasParam: false, sentencePre: 'When it is the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:root' },
   { type: PseudoClassType.SCOPE, hasParam: false, sentencePre: 'When it is within', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:scope' },
   { type: PseudoClassType.TARGET, hasParam: false, sentencePre: 'When URL matches', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:target' },
-  { type: PseudoClassType.BEFORE, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::before' },
-  { type: PseudoClassType.AFTER, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::after' },
-  { type: PseudoClassType.FIRST_LINE, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line' },
-  { type: PseudoClassType.FIRST_LETTER, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter' },
+  // Legacy pseudo-elements keep the single colon: existing sites saved them as :before etc.,
+  // and switching to :: would break their stored selectors. Migrate via grapesjs-version-flow later.
+  { type: PseudoClassType.BEFORE, hasParam: false, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::before' },
+  { type: PseudoClassType.AFTER, hasParam: false, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::after' },
+  { type: PseudoClassType.FIRST_LINE, hasParam: false, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line' },
+  { type: PseudoClassType.FIRST_LETTER, hasParam: false, sentencePre: 'Style the', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter' },
   { type: PseudoClassType.SELECTION, hasParam: false, isPseudoElement: true, sentencePre: 'Style the', sentencePost: 'pseudo-element', helpLink: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::selection' },
 
   // Form states


### PR DESCRIPTION
Ported from @JE4NVRG's grapesjs-advanced-selector#1 (authorship preserved); legacy pseudo-elements keep single colon for backward compat, :: only for the new ::selection. Fixes #1680