### PR TITLE
fix(publish): restore Download ZIP under archiver v8 (ESM ZipArchive)

### DIFF
--- a/server/plugins/DownloadConnector.publish.test.ts
+++ b/server/plugins/DownloadConnector.publish.test.ts
@@ -1,0 +1,32 @@
+import { expect, it, describe } from '@jest/globals'
+import { existsSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import DownloadConnector from './DownloadConnector.js'
+import { JobStatus } from '~/common/types.js'
+
+// Regression test for forum #250 / archiver v8 ESM bump.
+// archiver v8 is ESM-only and dropped the default factory (`archiver('zip', ...)`),
+// so `(await import('archiver')).default` became undefined and publishing threw
+// "archiver is not a function". This exercises the real zip pipeline end to end.
+describe('DownloadConnector publish (zip pipeline)', () => {
+  it('zips the website files and reports SUCCESS', async () => {
+    const connector = new DownloadConnector({ on: () => {} } as never)
+    const files = [
+      { path: 'index.html', content: '<h1>hi</h1>' },
+      { path: 'assets/img.txt', content: Buffer.from('pretend-image-bytes') },
+    ]
+    const job = { message: '', status: JobStatus.IN_PROGRESS } as never as { message: string; status: JobStatus }
+
+    await connector.startPublishingInBackground({} as never, 'website-regression' as never, files as never, job as never)
+
+    expect(job.status).toBe(JobStatus.SUCCESS)
+    // The success message exposes the download link with the generated file name.
+    const match = job.message.match(/\/download\/(website-regression-[^"]+\.zip)/)
+    expect(match).not.toBeNull()
+
+    const zipPath = join(tmpdir(), match![1])
+    expect(existsSync(zipPath)).toBe(true)
+    expect(statSync(zipPath).size).toBeGreaterThan(0)
+  })
+})

--- a/server/plugins/DownloadConnector.ts
+++ b/server/plugins/DownloadConnector.ts
@@ -86,7 +86,9 @@ export default class implements HostingConnector<DownloadConnectorSession> {
 
   async startPublishingInBackground(session: DownloadConnectorSession, websiteId: WebsiteId, files: ConnectorFile[], job: PublicationJobData): Promise<void> {
     const fileName = `${websiteId}-${Date.now()}-${Math.random().toString(36).substring(7)}.zip`
-    const archiver = (await import('archiver') as any).default
+    // archiver v8 is ESM and dropped the default factory (archiver('zip', ...)) in
+    // favour of named format classes. Use ZipArchive directly. See forum #250.
+    const { ZipArchive } = await import('archiver')
     return new Promise<string>((resolve, reject) => {
       let resolved = false
       try {
@@ -94,7 +96,7 @@ export default class implements HostingConnector<DownloadConnectorSession> {
         const path = `${tmpdir()}/${fileName}`
         // create a file to stream archive data to.
         const output = createWriteStream(path)
-        const archive = archiver('zip', {
+        const archive = new ZipArchive({
           zlib: { level: 9 } // Sets the compression level.
         })
 


### PR DESCRIPTION
Fixes Download ZIP publishing broken by the archiver 7 to 8 ESM bump ([forum](https://community.silex.me/d/250-cannot-publish-at-all/14))