### PR TITLE
ci(caprover): gate canary deploy on CI success (workflow_run)

### DIFF
--- a/.github/workflows/caprover.yml
+++ b/.github/workflows/caprover.yml
@@ -3,26 +3,37 @@ name: Deploy to CapRover
 # Deploys the server (root Dockerfile, referenced by the root captain-definition)
 # to CapRover: tar the tracked files (incl. submodule content) and upload via the caprover CLI.
 #
+# Canary deploys only after the CI workflow succeeds on main (workflow_run gate), so a
+# red build never reaches canary.silex.me. Production deploys on version tags.
+#
 # Required secrets:
 #   CAPROVER_SERVER        e.g. https://captain.your-domain.com
 #   CAPROVER_APP_CANARY    canary app name        + CAPROVER_APP_TOKEN_CANARY
 #   CAPROVER_APP_PROD      production app name     + CAPROVER_APP_TOKEN_PROD
 
 on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
   push:
-    branches: [main]
     tags: ['v*']
 
 jobs:
   canary:
     name: deploy canary
-    if: github.ref == 'refs/heads/main'
+    # Only when CI passed on main. workflow_run also fires for pull_request CI runs,
+    # hence the head_branch guard.
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true  # the SaaS serves silex-dashboard/_site
+          ref: ${{ github.event.workflow_run.head_sha }}  # deploy exactly what CI validated
       - name: Deploy to CapRover (canary)
         run: |
           git ls-files --recurse-submodules -z | tar --null --no-recursion -cf deploy.tar -T -
@@ -34,7 +45,7 @@ jobs:
 
   production:
     name: deploy production
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Canary now deploys only after the CI workflow passes on main, instead of racing it on every push.