### PR TITLE
feat(desktop): reproducible Linux builds + verified auto-update

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -98,6 +98,33 @@ jobs:
             exit 1
           fi
 
+      # Reproducible Linux build: pin timestamps/paths and normalize the mtimes
+      # rust-embed bakes into the binary, so the bundle is verifiable against source.
+      - name: Set deterministic build environment (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          EPOCH="$(git log -1 --pretty=%ct)"
+          echo "SOURCE_DATE_EPOCH=$EPOCH" >> "$GITHUB_ENV"
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+          echo "CARGO_NET_LOCKED=true" >> "$GITHUB_ENV"
+          echo "TZ=UTC" >> "$GITHUB_ENV"
+          echo "LC_ALL=C.UTF-8" >> "$GITHUB_ENV"
+          echo "RUSTFLAGS=--remap-path-prefix=$HOME/.cargo=/cargo --remap-path-prefix=$GITHUB_WORKSPACE=/build" >> "$GITHUB_ENV"
+          for dir in dist/client silex-dashboard-2026/public; do
+            [ -d "$dir" ] && find "$dir" -exec touch -h -d "@$EPOCH" {} +
+          done
+
+      # Record the sha256 of the compiled binary before Tauri stamps it per bundle
+      # type; this is the reproducibility reference (scripts/verify-reproducible.sh).
+      - name: Record reproducibility hash (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          cargo build --release --locked --manifest-path desktop/src-tauri/Cargo.toml
+          sha256sum target/release/silex-desktop | cut -d' ' -f1 > silex-desktop.sha256
+          echo "reproducible binary sha256: $(cat silex-desktop.sha256)"
+
       # Sign updater artifacts only on desktop-v* tags (secrets unavailable on fork PRs).
       - name: Build Tauri app (signed)
         if: startsWith(github.ref, 'refs/tags/desktop-v')
@@ -134,6 +161,7 @@ jobs:
         with:
           name: silex-desktop-${{ matrix.platform }}
           path: |
+            silex-desktop.sha256
             target/**/release/bundle/**/*.dmg
             target/**/release/bundle/**/*.AppImage
             target/**/release/bundle/**/*.deb
@@ -259,6 +287,21 @@ jobs:
           cat release/latest.json
           echo "--- release files ---"
           ls -lh release/
+
+      # Reproducibility checksums for the Linux artifacts. SHA256SUMS is download
+      # integrity for the installers; SHA256SUMS.inner is the compiled binary hash
+      # that scripts/verify-reproducible.sh rebuilds and matches (the installers
+      # wrap a per-format-stamped copy, so the binary is the reproducible unit).
+      - name: Compute reproducibility checksums (Linux)
+        working-directory: release
+        run: |
+          shopt -s nullglob
+          LINUX=( *_amd64.AppImage *.deb *.rpm )
+          [ ${#LINUX[@]} -eq 0 ] && { echo "no Linux artifacts, skipping"; exit 0; }
+          sha256sum "${LINUX[@]}" > SHA256SUMS
+          INNER="$(find .. -name silex-desktop.sha256 | head -1)"
+          [ -n "$INNER" ] && echo "$(cat "$INNER")  silex-desktop [reproducible binary — see scripts/README.md]" > SHA256SUMS.inner
+          echo "--- SHA256SUMS ---"; cat SHA256SUMS SHA256SUMS.inner 2>/dev/null
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/desktop/src-tauri/rust-toolchain.toml
+++ b/desktop/src-tauri/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# desktop/src-tauri/rust-toolchain.toml
+# Pins rustc so CI and any verifier build with the same toolchain.
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -247,6 +247,7 @@ fn check_for_updates(app: tauri::AppHandle) {
         match app.updater().expect("updater not configured").check().await {
             Ok(Some(update)) => {
                 let version = update.version.clone();
+                tracing::info!("Update available: v{}", version);
                 let app_clone = app.clone();
 
                 app.dialog()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,54 @@
+# Release verification scripts
+
+Tools to independently verify a Silex Desktop Linux release: that the published
+binary was built from this source, and that auto-updates are signed by the
+project's key. Linux only; macOS and Windows are out of scope.
+
+## Reproducible build — does the binary match the source?
+
+Linux binaries (appimage/deb/rpm) are reproducible: the compiled binary can be
+rebuilt from a tag and matched byte-for-byte against the release's
+`SHA256SUMS.inner`, without trusting our CI.
+
+```bash
+git clone --recurse-submodules https://github.com/silexlabs/Silex && cd Silex
+git checkout desktop-v0.1.0
+./scripts/verify-reproducible.sh <sha256-from-SHA256SUMS.inner>
+```
+
+`✅ reproducible` means your rebuild produced the same binary as the release.
+
+What makes it reproducible:
+- `desktop/src-tauri/rust-toolchain.toml` pins the Rust compiler.
+- `Cargo.lock` + `pnpm-lock.yaml` pin every dependency (`--locked`, `--frozen-lockfile`).
+- `repro-env.sh` pins `SOURCE_DATE_EPOCH`, remaps build paths out of the binary,
+  disables incremental compilation, forces UTC/C locale.
+- `build-desktop-repro.sh` (the release build entry point) also normalizes the
+  mtimes of the embedded frontend assets, which `rust-embed` bakes into the binary.
+
+The reproducible unit is the **compiled binary** (`silex-desktop`), in
+`SHA256SUMS.inner`. The installers wrap a copy Tauri stamps with its bundle type,
+and the wrapper formats vary across `mksquashfs`/`dpkg`/`rpmbuild` — so
+verification targets the binary, not the installer. `SHA256SUMS` covers the
+installers for download integrity.
+
+## Auto-update — is the update signed by the project?
+
+The in-app updater only installs packages signed by the private key matching the
+public key embedded in `desktop/src-tauri/tauri.conf.json`. This checks that the
+published update feed is signed by that key (the same check the app runs):
+
+```bash
+./scripts/verify-update-signature.sh            # checks releases/latest
+```
+
+Requires `rsign` (`cargo install rsign2`) or `minisign`, plus `jq` and `curl`.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `verify-reproducible.sh` | Rebuild the current tag and compare to `SHA256SUMS.inner` |
+| `verify-update-signature.sh` | Verify the update feed's signature against the embedded key |
+| `build-desktop-repro.sh` | Produce the release build deterministically (used by CI) |
+| `repro-env.sh` | Deterministic build environment (sourced by the above) |

--- a/scripts/build-desktop-repro.sh
+++ b/scripts/build-desktop-repro.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Reproducible Linux build of Silex Desktop (appimage, deb, rpm).
+# Normalizes embedded-asset mtimes (rust-embed captures them) then builds with
+# the deterministic environment. Used by CI and by anyone reproducing a release.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+source scripts/repro-env.sh
+
+# rust-embed bakes file mtimes into the binary; pin them so a fresh checkout
+# (git sets mtime to checkout time) yields identical bytes.
+for dir in dist/client silex-dashboard-2026/public; do
+  [ -d "$dir" ] && find "$dir" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+done
+
+( cd desktop && pnpm tauri build )

--- a/scripts/repro-env.sh
+++ b/scripts/repro-env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Deterministic build environment for Silex Desktop (Linux).
+# Source it — don't execute. Used by CI and verify-reproducible.sh.
+set -eu
+
+: "${SOURCE_DATE_EPOCH:=$(git log -1 --pretty=%ct)}"
+export SOURCE_DATE_EPOCH
+export RUSTFLAGS="${RUSTFLAGS:-} --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=/cargo --remap-path-prefix=${PWD}=/build"
+export CARGO_INCREMENTAL=0
+export CARGO_NET_LOCKED=true
+export TZ=UTC
+export LC_ALL=C.UTF-8
+export APPIMAGE_EXTRACT_AND_RUN=1

--- a/scripts/verify-reproducible.sh
+++ b/scripts/verify-reproducible.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Verify the current checkout reproduces a published Silex Desktop binary.
+#
+# Run from a clean checkout at the release tag:
+#   git clone --recurse-submodules https://github.com/silexlabs/Silex && cd Silex
+#   git checkout desktop-v0.1.0
+#   ./scripts/verify-reproducible.sh [expected-sha256]
+#
+# Rebuilds the binary with the deterministic env + pinned toolchain and compares
+# its sha256 to the release's SHA256SUMS.inner. Needs the Rust/Node toolchain,
+# not the AppImage bundler.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+source scripts/repro-env.sh
+
+corepack enable >/dev/null 2>&1 || true
+pnpm install --frozen-lockfile --filter @silexlabs/silex --filter @silexlabs/silex-desktop
+pnpm run build
+for d in dist/client silex-dashboard-2026/public; do
+  [ -d "$d" ] && find "$d" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+done
+cargo build --release --locked --manifest-path desktop/src-tauri/Cargo.toml
+
+REBUILT="$(sha256sum desktop/src-tauri/target/release/silex-desktop | cut -d' ' -f1)"
+echo "rebuilt binary sha256: $REBUILT"
+
+EXPECTED="${1:-}"
+if [ -z "$EXPECTED" ]; then
+  echo "compare this against SHA256SUMS.inner from the release"
+  exit 0
+fi
+[ "$REBUILT" = "$EXPECTED" ] && echo "✅ reproducible" || { echo "❌ mismatch (expected $EXPECTED)"; exit 1; }

--- a/scripts/verify-update-signature.sh
+++ b/scripts/verify-update-signature.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Verify the published auto-update feed is signed by the key the app trusts.
+#
+# Usage:
+#   ./scripts/verify-update-signature.sh [latest.json-url]
+#
+# Downloads the update feed + its Linux artifact and checks the signature against
+# the pubkey embedded in tauri.conf.json — the same check the in-app updater runs
+# before installing. A tampered artifact or a wrong key fails here.
+# Requires: rsign (cargo install rsign2) or minisign, plus jq and curl.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+ENDPOINT="${1:-https://github.com/silexlabs/Silex/releases/latest/download/latest.json}"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+grep -o '"pubkey": *"[^"]*"' desktop/src-tauri/tauri.conf.json \
+  | sed 's/.*"pubkey": *"//;s/"//' | base64 -d > "$TMP/pub"
+
+curl -sSL "$ENDPOINT" -o "$TMP/latest.json"
+URL="$(jq -r '.platforms."linux-x86_64".url' "$TMP/latest.json")"
+jq -r '.platforms."linux-x86_64".signature' "$TMP/latest.json" | base64 -d > "$TMP/art.sig"
+echo "feed version: $(jq -r .version "$TMP/latest.json")"
+echo "artifact:     $URL"
+curl -sSL "$URL" -o "$TMP/art"
+
+if command -v rsign >/dev/null; then
+  rsign verify -p "$TMP/pub" -x "$TMP/art.sig" "$TMP/art"
+elif command -v minisign >/dev/null; then
+  minisign -Vm "$TMP/art" -p "$TMP/pub" -x "$TMP/art.sig"
+else
+  echo "need rsign (cargo install rsign2) or minisign" >&2; exit 2
+fi


### PR DESCRIPTION
Reproducible Linux builds (appimage/deb/rpm) verifiable against source, and end-to-end verified auto-update. See scripts/README.md.

Closes #1740

Funded by NLnet through the NGI0 Commons Fund (project 2025-10-133), with support from the European Commission's NGI programme.