### PR TITLE
fix(desktop): ship desktop from v* releases so the updater feed stays valid

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -303,6 +303,28 @@ jobs:
           [ -n "$INNER" ] && echo "$(cat "$INNER")  silex-desktop [reproducible binary — see scripts/README.md]" > SHA256SUMS.inner
           echo "--- SHA256SUMS ---"; cat SHA256SUMS SHA256SUMS.inner 2>/dev/null
 
+      # Version-less copies of each installer, so the download page can use permanent
+      # links like releases/latest/download/Silex_amd64.AppImage (asset names carry the
+      # version, which would otherwise break the link on every release).
+      - name: Add version-less download aliases
+        working-directory: release
+        run: |
+          shopt -s nullglob
+          copy_alias() {  # $1 = glob of the versioned file, $2 = stable name
+            for f in $1; do
+              [ "$f" = "$2" ] && continue
+              cp -f "$f" "$2" && echo "$2 <- $f"
+              return
+            done
+          }
+          copy_alias '*_amd64.AppImage' Silex_amd64.AppImage
+          copy_alias '*_amd64.deb'      Silex_amd64.deb
+          copy_alias '*.x86_64.rpm'     Silex_x86_64.rpm
+          copy_alias '*_aarch64.dmg'    Silex_aarch64.dmg
+          copy_alias '*_x64.dmg'        Silex_x64.dmg
+          copy_alias '*_x64-setup.exe'  Silex_x64-setup.exe
+          ls -1
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -2,7 +2,7 @@ name: Desktop release
 
 on:
   push:
-    tags: ['desktop-v*']
+    tags: ['v*']
   pull_request:
     branches: [main]
 
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   # Linux-only on PRs (Rust+TS is shared, so linux catches almost all breakage);
-  # full 4-platform matrix only on desktop-v* tags, where the costly macOS/Windows
+  # full 4-platform matrix only on v* tags, where the costly macOS/Windows
   # runners are worth it. No per-commit main build — the PR already covered it.
   set-matrix:
     runs-on: ubuntu-latest
@@ -21,7 +21,7 @@ jobs:
       - id: m
         shell: bash
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/desktop-v* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             echo 'matrix={"include":[{"platform":"linux","os":"ubuntu-latest"},{"platform":"macos-arm","os":"macos-latest"},{"platform":"macos-x64","os":"macos-latest","rust-target":"x86_64-apple-darwin"},{"platform":"windows","os":"windows-latest"}]}' >> "$GITHUB_OUTPUT"
           else
             echo 'matrix={"include":[{"platform":"linux","os":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
@@ -73,10 +73,10 @@ jobs:
       # updater metadata carry the release version (Tauri reads it from tauri.conf.json;
       # a stale value would nag users to "update" to the same version).
       - name: Patch desktop version from tag
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
+        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
-          V="${GITHUB_REF_NAME#desktop-v}"
+          V="${GITHUB_REF_NAME#v}"
           jq --arg v "$V" '.version = $v' desktop/src-tauri/tauri.conf.json > /tmp/tauri.conf.json
           mv /tmp/tauri.conf.json desktop/src-tauri/tauri.conf.json
           ACTUAL="$(jq -r '.version' desktop/src-tauri/tauri.conf.json)"
@@ -125,9 +125,9 @@ jobs:
           sha256sum target/release/silex-desktop | cut -d' ' -f1 > silex-desktop.sha256
           echo "reproducible binary sha256: $(cat silex-desktop.sha256)"
 
-      # Sign updater artifacts only on desktop-v* tags (secrets unavailable on fork PRs).
+      # Sign updater artifacts only on v* tags (secrets unavailable on fork PRs).
       - name: Build Tauri app (signed)
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -140,12 +140,12 @@ jobs:
           args: ${{ matrix.rust-target && format('--target {0}', matrix.rust-target) || '' }}
 
       - name: Disable updater artifacts config
-        if: ${{ !startsWith(github.ref, 'refs/tags/desktop-v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: echo '{"bundle":{"createUpdaterArtifacts":false}}' > desktop/tauri.ci.json
 
       - name: Build Tauri app (unsigned)
-        if: ${{ !startsWith(github.ref, 'refs/tags/desktop-v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -173,7 +173,7 @@ jobs:
 
   release:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/desktop-v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -190,9 +190,9 @@ jobs:
           # Previous desktop tag of the same type (prerelease or stable)
           CURRENT="${GITHUB_REF_NAME}"
           if [[ "$CURRENT" == *-* ]]; then
-            PREV=$(git tag --sort=-version:refname | grep -E '^desktop-v.*-' | grep -v "^${CURRENT}$" | head -1)
+            PREV=$(git tag --sort=-version:refname | grep -E '^v.*-' | grep -v "^${CURRENT}$" | head -1)
           else
-            PREV=$(git tag --sort=-version:refname | grep -E '^desktop-v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${CURRENT}$" | head -1)
+            PREV=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${CURRENT}$" | head -1)
           fi
           echo "tag=${PREV:-}" >> "$GITHUB_OUTPUT"
           echo "Previous tag: ${PREV:-none}"
@@ -234,7 +234,7 @@ jobs:
           # macOS updater bundles are named Silex.app.tar.gz on both arches — rename per-arch.
           # Cross-builds leave an unsigned native bundle next to the signed one: pick only
           # the bundle that has its .sig sibling.
-          V="${VERSION#desktop-v}"
+          V="${VERSION#v}"
           for pair in "macos-arm aarch64" "macos-x64 x64"; do
             set -- $pair
             SRC=$(find "artifacts/silex-desktop-$1" -name '*.app.tar.gz' ! -name '*.sig' \


### PR DESCRIPTION
Desktop ships from `v*` tags (the `desktop-v*` channel was unused) so `releases/latest` always has a valid `latest.json`; also publishes version-less installer aliases for permanent download links.
