### PR TITLE
fix(ci): add cross target to the pinned rust toolchain for macos-x64 desktop build

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -60,6 +60,13 @@ jobs:
         with:
           targets: ${{ matrix.rust-target || '' }}
 
+      # The build runs under the toolchain pinned by desktop/src-tauri/rust-toolchain.toml,
+      # which only ships the host target — add the cross target to it too.
+      - name: Add cross target to pinned toolchain
+        if: matrix.rust-target
+        working-directory: desktop/src-tauri
+        run: rustup target add ${{ matrix.rust-target }}
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
 


### PR DESCRIPTION
The macos-x64 cross build fails on v* tags: the build uses the toolchain pinned by `rust-toolchain.toml`, which only has the host target. Caught by the v3.9.0-canary.0 test.