### PR TITLE
feat(ci): publish @silexlabs/silex to npm on v* tags via OIDC trusted publisher

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,58 @@
+name: npm package
+
+# Publishes @silexlabs/silex on every v* tag: prerelease tags (v3.9.0-canary.1)
+# go to the `canary` dist-tag, stable tags to `latest`. The version is patched
+# from the tag at build time (package.json is not bumped in git).
+# Auth: npm Trusted Publisher (OIDC) — the package settings on npmjs.com trust
+# this repo + workflow file, no token or secret involved.
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  id-token: write  # OIDC token for npm trusted publishing
+  contents: read
+
+jobs:
+  publish:
+    name: build and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      # pnpm via action-setup AFTER setup-node so its standalone binary wins in PATH
+      # over node's bundled corepack shim (whose signing keys are stale and break
+      # `pnpm` invocations). No cache:pnpm — it would call corepack during setup-node.
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter @silexlabs/silex
+
+      - name: Build
+        run: pnpm build
+
+      # Tags are not gated by the CI workflow — lint and test before publishing,
+      # like the legacy silex-lib npm-publish.yml did.
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Patch version from tag
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
+
+      # OIDC trusted publishing needs npm >= 11.5.1 (node's bundled npm may lag)
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Publish (OIDC trusted publisher)
+        run: npm publish --provenance --access public --tag ${{ contains(github.ref_name, '-') && 'canary' || 'latest' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,8 @@ We use a trunk-based model: `main` is the single, always-releasable branch.
 
 Two kinds of tags:
 
-- **Prerelease tags** (e.g. `v3.9.0-canary.1`, `-alpha`, `-beta`) — deploy to **canary** ([canary.silex.me](https://canary.silex.me)) for testing, publish a GitHub *prerelease* of the desktop apps, and publish the versioned `silexlabs/silex-platform` Docker image (also tagged `:canary`, never `:latest`). Nothing reaches production, and prerelease builds are never offered to stable users by the auto-updater.
-- **Stable tags** (e.g. `v3.9.0`) — deploy the server to CapRover **production** ([v3.silex.me](https://v3.silex.me)), publish the `silexlabs/silex-platform` Docker image (versioned + `:latest`), and publish the stable desktop release (macOS/Windows/Linux) with auto-updater metadata.
+- **Prerelease tags** (e.g. `v3.9.0-canary.1`, `-alpha`, `-beta`) — deploy to **canary** ([canary.silex.me](https://canary.silex.me)) for testing, publish a GitHub *prerelease* of the desktop apps, publish the versioned `silexlabs/silex-platform` Docker image (also tagged `:canary`, never `:latest`), and publish `@silexlabs/silex` to npm under the `canary` dist-tag. Nothing reaches production, and prerelease builds are never offered to stable users by the auto-updater.
+- **Stable tags** (e.g. `v3.9.0`) — deploy the server to CapRover **production** ([v3.silex.me](https://v3.silex.me)), publish the `silexlabs/silex-platform` Docker image (versioned + `:latest`), publish `@silexlabs/silex` to npm as `latest`, and publish the stable desktop release (macOS/Windows/Linux) with auto-updater metadata.
 
 In both cases the desktop GitHub release is created as a **draft** — a maintainer reviews and publishes it (the SaaS/Docker deploys are immediate). To test a build, cut a prerelease tag (it lands on canary); to release, cut a stable tag once canary is validated. Releases are cut by maintainers by tagging `main`.
 


### PR DESCRIPTION
Restores the npm publishing lost in the monorepo migration (last publish: 3.7.0 from silex-lib on 2026-06-16). Version patched from the tag; prerelease tags publish under the `canary` dist-tag, stable tags under `latest`. Auth via npm Trusted Publisher (OIDC) — no token, the package settings trust this repo + `npm.yml`.