### PR TITLE
fix(ci): move rust-toolchain.toml to the repo root so the pin actually applies

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
-# desktop/src-tauri/rust-toolchain.toml
+# rust-toolchain.toml (repo root: rustup resolves it from any cwd in the workspace)
 # Pins rustc so CI and any verifier build with the same toolchain.
 [toolchain]
 channel = "1.95.0"


### PR DESCRIPTION
rustup only resolves rust-toolchain.toml walking up from the current directory => it was invisible to CI, which broke reproducible-build verification

Refs #1740. Funded by NLnet through the NGI0 Commons Fund (project 2025-10-133), with support from the European Commission's NGI programme.