### PR TITLE
fix(desktop): mcp tool names and reliable style targeting for ai agents

### DIFF
--- a/desktop/src-tauri/src/mcp.rs
+++ b/desktop/src-tauri/src/mcp.rs
@@ -286,7 +286,8 @@ impl SilexMcp {
             };
 
             let tool = Tool {
-                name: cap.id.clone().into(),
+                // ':' in capability ids is not allowed in tool names (clients require ^[a-zA-Z0-9_-]+$)
+                name: cap.id.replace(':', "_").into(),
                 title: None,
                 description: Some(cap.description.into()),
                 input_schema: Arc::new(schema_obj),

--- a/editor/grapesjs/core-commands.ts
+++ b/editor/grapesjs/core-commands.ts
@@ -101,39 +101,6 @@ export default (editor: Editor) => {
     }
   })
 
-  // Styles (operate on the active CSS rule, not inline styles)
-  editor.Commands.add('styles:get', () => {
-    const rule = (editor as any).StyleManager?.getSelected?.()
-    if (!rule) throw new Error('No selector active. Use selector:edit-style first.')
-    return {
-      selector: rule.selectorsToString?.() ?? '',
-      style: rule.getStyle(),
-      mediaText: rule.get('mediaText') ?? '',
-    }
-  })
-  editor.Commands.add('styles:set', (_ed, _sender, options: any = {}) => {
-    const rule = (editor as any).StyleManager?.getSelected?.()
-    if (!rule) throw new Error('No selector active. Use selector:edit-style first.')
-    const { property, value, ...rest } = options
-    const existing = rule.getStyle?.() ?? {}
-    if (property && value !== undefined) {
-      rule.setStyle({ ...existing, [property]: value })
-    } else if (Object.keys(rest).length) {
-      rule.setStyle({ ...existing, ...rest })
-    } else {
-      throw new Error('Required: {property, value} or CSS key-value pairs. Example: {property: "color", value: "red"} or {"color": "red", "font-size": "16px"}')
-    }
-  })
-  editor.Commands.add('styles:remove', (_ed, _sender, options: any = {}) => {
-    const rule = (editor as any).StyleManager?.getSelected?.()
-    if (!rule) throw new Error('No selector active. Use selector:edit-style first.')
-    const { property } = options
-    if (!property) throw new Error('Required: property (CSS property name, e.g. "color", "font-size", "margin")')
-    const style = rule.getStyle()
-    delete style[property]
-    rule.setStyle(style)
-  })
-
   // CSS Classes
   editor.Commands.add('classes:list', () => {
     const selected = editor.getSelected()
@@ -264,40 +231,6 @@ export default (editor: Editor) => {
         },
       },
       tags: ['components'],
-    })
-    addCapability({
-      id: 'styles:get',
-      command: 'styles:get',
-      description: 'Get CSS styles from the active selector (set via selector:edit-style)',
-      readOnly: true,
-      tags: ['styles'],
-    })
-    addCapability({
-      id: 'styles:set',
-      command: 'styles:set',
-      description: 'Set CSS style on the active selector (set via selector:edit-style)',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          property: { type: 'string' },
-          value: { type: 'string' },
-        },
-      },
-      tags: ['styles'],
-    })
-    addCapability({
-      id: 'styles:remove',
-      command: 'styles:remove',
-      description: 'Remove a CSS property from the active selector (set via selector:edit-style)',
-      destructive: true,
-      inputSchema: {
-        type: 'object',
-        required: ['property'],
-        properties: {
-          property: { type: 'string' },
-        },
-      },
-      tags: ['styles'],
     })
     addCapability({
       id: 'classes:list',

--- a/grapesjs-plugins/grapesjs-advanced-selector/src/capabilities.ts
+++ b/grapesjs-plugins/grapesjs-advanced-selector/src/capabilities.ts
@@ -27,17 +27,38 @@ export function registerCapabilities(addCapability: (def: Record<string, unknown
     tags: ['selectors'],
   })
   addCapability({
-    id: 'selector:edit-style',
-    command: 'selector:edit-style',
-    description: 'Activate a selector for styling (use before styles:set)',
+    id: 'styles:get',
+    command: 'styles:get',
+    description: 'Get CSS styles from the active selector (set via selector:set)',
+    readOnly: true,
+    tags: ['styles'],
+  })
+  addCapability({
+    id: 'styles:set',
+    command: 'styles:set',
+    description: 'Set CSS style on the active selector (set via selector:set)',
     inputSchema: {
       type: 'object',
-      required: ['selector'],
       properties: {
-        selector: { type: 'string', description: 'CSS selector to activate for style editing' },
+        property: { type: 'string' },
+        value: { type: 'string' },
       },
     },
-    tags: ['selectors'],
+    tags: ['styles'],
+  })
+  addCapability({
+    id: 'styles:remove',
+    command: 'styles:remove',
+    description: 'Remove a CSS property from the active selector (set via selector:set)',
+    destructive: true,
+    inputSchema: {
+      type: 'object',
+      required: ['property'],
+      properties: {
+        property: { type: 'string' },
+      },
+    },
+    tags: ['styles'],
   })
   addCapability({
     id: 'selector:info',

--- a/grapesjs-plugins/grapesjs-advanced-selector/src/commands.ts
+++ b/grapesjs-plugins/grapesjs-advanced-selector/src/commands.ts
@@ -1,6 +1,6 @@
 import { Editor } from 'grapesjs'
-import { getComponentSelector, setComponentSelector, editStyle, getSelectors } from './model/GrapesJsSelectors'
-import { toString as complexSelectorToString, fromString as complexSelectorFromString } from './model/ComplexSelector'
+import { getComponentSelector, setComponentSelector, editStyle, getSelectors, getOrCreateRule } from './model/GrapesJsSelectors'
+import { toString as complexSelectorToString, fromString as complexSelectorFromString, getSelector } from './model/ComplexSelector'
 import { PseudoClassType } from './model/PseudoClass'
 import { OperatorType } from './model/Operator'
 
@@ -53,16 +53,54 @@ export default function registerCommands(editor: Editor) {
     },
   })
 
-  editor.Commands.add('selector:edit-style', {
-    run(_ed: Editor, _sender: unknown, cmdOpts: { selector?: string } = {}) {
-      const { selector } = cmdOpts
-      if (!selector) throw new Error('Required: selector (CSS selector string to activate for styling). Use selector:get to see current selector, or selector:list-rules to see all rules.')
-      try {
-        editStyle(editor, selector)
-      } catch(e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e)
-        throw new Error(`Cannot edit style for "${selector}". ${msg}`, { cause: e })
+  // Resolve the styling target from the component's stored selector at call
+  // time — StyleManager.getSelected() is unreliable here: it is set by a race
+  // between GrapesJS's native targeting and the panel's debounced re-selection
+  const activeRule = () => {
+    const components = editor.getSelectedAll()
+    const cs = getSelector(components)
+    if (!cs) throw new Error('No component selected. Use components:select first.')
+    const selStr = complexSelectorToString(cs)
+    if (!selStr) throw new Error('No selector active. Use selector:set first.')
+    const rule = getOrCreateRule(editor, selStr)
+    editor.StyleManager.select(rule)
+    return rule
+  }
+
+  editor.Commands.add('styles:get', {
+    run() {
+      const rule = activeRule()
+      return {
+        selector: rule.selectorsToString?.() ?? '',
+        style: rule.getStyle(),
+        mediaText: rule.get('mediaText') ?? '',
       }
+    },
+  })
+
+  editor.Commands.add('styles:set', {
+    run(_ed: Editor, _sender: unknown, cmdOpts: Record<string, string> = {}) {
+      const rule = activeRule()
+      const { property, value, ...rest } = cmdOpts
+      const existing = rule.getStyle?.() ?? {}
+      if (property && value !== undefined) {
+        rule.setStyle({ ...existing, [property]: value })
+      } else if (Object.keys(rest).length) {
+        rule.setStyle({ ...existing, ...rest })
+      } else {
+        throw new Error('Required: {property, value} or CSS key-value pairs. Example: {property: "color", value: "red"} or {"color": "red", "font-size": "16px"}')
+      }
+    },
+  })
+
+  editor.Commands.add('styles:remove', {
+    run(_ed: Editor, _sender: unknown, cmdOpts: { property?: string } = {}) {
+      const rule = activeRule()
+      const { property } = cmdOpts
+      if (!property) throw new Error('Required: property (CSS property name, e.g. "color", "font-size", "margin")')
+      const style = rule.getStyle()
+      delete style[property]
+      rule.setStyle(style)
     },
   })
 

--- a/grapesjs-plugins/grapesjs-advanced-selector/src/model/GrapesJsSelectors.ts
+++ b/grapesjs-plugins/grapesjs-advanced-selector/src/model/GrapesJsSelectors.ts
@@ -92,7 +92,7 @@ export function getSelectors(editor: Editor): ComplexSelector[] {
 /**
  * Function to edit or add style based on the selector
  */
-export function editStyle(editor: Editor, selector: string) {
+export function getOrCreateRule(editor: Editor, selector: string) {
   const currentWidth = editor.DeviceManager.getSelected()?.get('widthMedia')
 
   const opts = {
@@ -100,11 +100,14 @@ export function editStyle(editor: Editor, selector: string) {
     atRuleParams: currentWidth ? `(max-width: ${currentWidth})` : '',
   }
   const old = editor.CssComposer.getRule(selector, opts)
-  const rule = editor.CssComposer.setRule(selector, old?.getStyle(), {
+  return editor.CssComposer.setRule(selector, old?.getStyle(), {
     addStyles: !!old?.getStyle(),
     ...opts,
   })
-  editor.StyleManager.select(rule)
+}
+
+export function editStyle(editor: Editor, selector: string) {
+  editor.StyleManager.select(getOrCreateRule(editor, selector))
 }
 
 /**


### PR DESCRIPTION
Refs #1773 — sanitize mcp tool names (':' broke gpt-codex/gemini) and make styles:set/get/remove target the component's stored selector at call time (a race with the selector panel made them write to the wrong rule, e.g. #id instead of the class); selector:edit-style is removed in favor of selector:set.