### PR TITLE
 Add horizontal center button to component toolbar

### DIFF
--- a/editor/grapesjs/center.ts
+++ b/editor/grapesjs/center.ts
@@ -1,0 +1,54 @@
+import { Editor } from 'grapesjs'
+
+const CENTER_COMMAND = 'silex:center-h'
+
+export default (editor: Editor) => {
+  editor.Commands.add(CENTER_COMMAND, () => {
+    const cmp = editor.getSelected()
+    if (!cmp) return
+
+    const style = cmp.getStyle()
+    const isCentered =
+        style['margin-left'] === 'auto' &&
+        style['margin-right'] === 'auto'
+
+    if (isCentered) {
+      const {
+        ['margin-left']: _marginLeft,
+        ['margin-right']: _marginRight,
+        ...newStyle
+      } = style
+
+      cmp.setStyle(newStyle)
+      return
+    }
+
+    cmp.setStyle({
+      ...style,
+      'margin-left': 'auto',
+      'margin-right': 'auto',
+    })
+  })
+
+  const defaultModel = editor.Components.getType('default').model as any
+  const originalDefaults = defaultModel.prototype.defaults
+
+  defaultModel.prototype.defaults = function () {
+    const defaults = originalDefaults.call(this)
+
+    return {
+      ...defaults,
+      toolbar: [
+        ...(defaults.toolbar || []),
+        {
+          attributes: {
+            class: 'fa-solid fa-align-center',
+            title: 'Center horizontally',
+            'aria-label': 'Center horizontally',
+          },
+          command: CENTER_COMMAND,
+        },
+      ],
+    }
+  }
+}

--- a/editor/grapesjs/center.ts
+++ b/editor/grapesjs/center.ts
@@ -30,13 +30,13 @@ export default (editor: Editor) => {
     })
   })
 
-  const defaultModel = editor.DomComponents.getType('default').model as any
-  const defaults = defaultModel.prototype.defaults
+  editor.on('component:selected', component => {
+    if (component.toolbar.some(item => item.command === CENTER_COMMAND)) {
+      return
+    }
 
-  defaultModel.prototype.defaults = {
-    ...defaults,
-    toolbar: [
-      ...(defaults.toolbar || []),
+    component.set('toolbar', [
+      ...component.toolbar,
       {
         attributes: {
           class: 'fa-solid fa-align-center',
@@ -45,6 +45,6 @@ export default (editor: Editor) => {
         },
         command: CENTER_COMMAND,
       },
-    ],
-  }
+    ])
+  })
 }

--- a/editor/grapesjs/center.ts
+++ b/editor/grapesjs/center.ts
@@ -1,3 +1,19 @@
+/*
+ * Silex website builder, free/libre no-code tool for makers.
+ * Copyright (c) 2023 lexoyo and Silex Labs foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 import { Editor } from 'grapesjs'
 
 const CENTER_COMMAND = 'silex:center-h'

--- a/editor/grapesjs/center.ts
+++ b/editor/grapesjs/center.ts
@@ -30,25 +30,21 @@ export default (editor: Editor) => {
     })
   })
 
-  const defaultModel = editor.Components.getType('default').model as any
-  const originalDefaults = defaultModel.prototype.defaults
+  const defaultModel = editor.DomComponents.getType('default').model as any
+  const defaults = defaultModel.prototype.defaults
 
-  defaultModel.prototype.defaults = function () {
-    const defaults = originalDefaults.call(this)
-
-    return {
-      ...defaults,
-      toolbar: [
-        ...(defaults.toolbar || []),
-        {
-          attributes: {
-            class: 'fa-solid fa-align-center',
-            title: 'Center horizontally',
-            'aria-label': 'Center horizontally',
-          },
-          command: CENTER_COMMAND,
+  defaultModel.prototype.defaults = {
+    ...defaults,
+    toolbar: [
+      ...(defaults.toolbar || []),
+      {
+        attributes: {
+          class: 'fa-solid fa-align-center',
+          title: 'Center horizontally',
+          'aria-label': 'Center horizontally',
         },
-      ],
-    }
+        command: CENTER_COMMAND,
+      },
+    ],
   }
 }

--- a/editor/grapesjs/index.ts
+++ b/editor/grapesjs/index.ts
@@ -48,6 +48,7 @@ import breadcrumbsPlugin from './breadcrumbs'
 import imgPlugin from './img'
 import liPlugin from './li'
 import flexPlugin from './flex'
+import centerPlugin from './center'
 import cssPropsPlugin from './css-props'
 import rateLimitPlugin from '@silexlabs/grapesjs-storage-rate-limit'
 import borderPlugin from 'grapesjs-style-border'
@@ -112,6 +113,7 @@ const plugins = [
   {name: './img', value: imgPlugin},
   {name: './li', value: liPlugin},
   {name: './flex', value: flexPlugin},
+  {name: './center', value: centerPlugin},
   {name: './css-props', value: cssPropsPlugin},
   {name: './footer', value: footerPlugin},
   {name: '@silexlabs/grapesjs-storage-rate-limit', value: rateLimitPlugin},


### PR DESCRIPTION
Fixes #1799

Adds a Center horizontally toolbar action for selected components.

 - Applies `margin-left: auto` and `margin-right: auto` through the component API
 - Clicking the action again removes both properties
 - Uses a Font Awesome center-alignment icon with an accessible label

 Validation:
 - `corepack pnpm lint`
 - `corepack pnpm run build:client`
 - `corepack pnpm run build:server`