### PR TITLE
chore(desktop): remove dead bridge helpers, unused dep and stale docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,7 +4125,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "url",
  "uuid",
 ]
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -26,9 +26,6 @@ cd desktop
 pnpm run dev       # = tauri dev
 ```
 
-The editor and the dashboard are compiled into the binary, so build them before running the app
-(`pnpm run build:client` at the root of the repo).
-
 Set `SILEX_DATA_PATH` to keep the websites of your development runs away from the ones of the
 installed app.
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@silexlabs/silex-desktop",
   "version": "0.0.0-dev",
   "description": "Silex website builder - desktop app powered by Tauri",
-  "license": "GPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -21,11 +21,11 @@ tokio = { version = "1", features = ["full"] }
 axum = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2"
 
 # MCP (Model Context Protocol) support
 reqwest = { version = "0.13", features = ["json"] }
 rmcp = { version = "0.15", features = ["server", "transport-streamable-http-server", "transport-io"] }
+# Required as a direct dependency: the JsonSchema derive expands to ::schemars paths
 schemars = "1"
 
 # Open files/folders in the OS default application

--- a/desktop/src-tauri/scripts/desktop-bridge.js
+++ b/desktop/src-tauri/scripts/desktop-bridge.js
@@ -39,146 +39,14 @@
     });
   };
 
-  const TEXT_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'li', 'td', 'th', 'label', 'blockquote'];
-
   // Expose debug logging for silex-lib client code
   window.__silexDebug = (msg) => invoke('log_debug', { message: msg });
   invoke('log_debug', { message: '[bridge] desktop-bridge loaded, page=' + window.location.href });
 
-  // MCP helpers (available globally for eval_js calls)
+  // MCP helpers, called by the Rust side through eval_js.
+  // Nothing else belongs here: a capability's own logic lives in its plugin.
   window.__silexMcp = {
-    findComponent(editor, id) {
-      const walk = (c) => {
-        if (c.ccid === id || c.getId() === id) return c;
-        for (const child of c.components().models) {
-          const r = walk(child);
-          if (r) return r;
-        }
-        return null;
-      };
-      return walk(editor.getWrapper());
-    },
-
-    getDataSourceApi() {
-      return window.silex?.dataSource ?? null;
-    },
-
-    resolveExpression(editor, dotPath) {
-      const dsApi = this.getDataSourceApi();
-      if (!dsApi?.getAllDataSources) {
-        return { error: 'Data source plugin not available. No CMS configured.' };
-      }
-
-      const parts = dotPath.split('.');
-      if (parts.length < 2) return { error: 'Expression must have at least 2 segments: "source.field"' };
-
-      const [dsId, ...fieldParts] = parts;
-      const ds = dsApi.getDataSource(dsId);
-      if (!ds) {
-        const available = dsApi.getAllDataSources().map(d => d.id);
-        return { error: `Data source not found: ${dsId}`, available };
-      }
-
-      const tokens = [];
-      let currentTypeIds = [];
-
-      // First field segment: look up in queryables (root entry points)
-      const fieldId = fieldParts[0];
-      const queryables = ds.getQueryables?.() ?? [];
-      const rootField = queryables.find(q => q.id === fieldId);
-      if (!rootField) {
-        return {
-          error: `Field not found: ${fieldId}`,
-          available: queryables.map(f => f.id)
-        };
-      }
-
-      tokens.push({
-        type: 'property',
-        propType: 'field',
-        dataSourceId: dsId,
-        fieldId: rootField.id,
-        label: rootField.label ?? rootField.id,
-        typeIds: rootField.typeIds ?? [],
-        kind: rootField.kind ?? 'object'
-      });
-      currentTypeIds = rootField.typeIds ?? [];
-
-      // Remaining segments: traverse nested fields through types
-      for (let seg = 1; seg < fieldParts.length; seg++) {
-        const nextFieldId = fieldParts[seg];
-        let found = false;
-        const availableFields = [];
-        const allTypes = ds.getTypes?.() ?? [];
-
-        for (const t of allTypes) {
-          if (!currentTypeIds.includes(t.id)) continue;
-
-          for (const field of (t.fields ?? [])) {
-            availableFields.push(field.id);
-            if (field.id === nextFieldId) {
-              tokens.push({
-                type: 'property',
-                propType: 'field',
-                fieldId: field.id,
-                label: field.label ?? field.id,
-                typeIds: field.typeIds ?? [],
-                kind: field.kind ?? 'scalar'
-              });
-              currentTypeIds = field.typeIds ?? [];
-              found = true;
-              break;
-            }
-          }
-          if (found) break;
-        }
-
-        if (!found) {
-          return {
-            error: `Field not found at segment ${seg + 1}: ${nextFieldId}`,
-            path_so_far: parts.slice(0, seg + 2).join('.'),
-            available: availableFields
-          };
-        }
-      }
-
-      return tokens;
-    },
-
-    setState(component, stateId, state, exported) {
-      const dsApi = this.getDataSourceApi();
-      if (dsApi?.setState) {
-        dsApi.setState(component, stateId, state, exported);
-        return;
-      }
-      // Fallback: direct component manipulation (no change callbacks)
-      const key = exported ? 'publicStates' : 'privateStates';
-      const states = component.get(key) ?? [];
-      const entry = { id: stateId, label: state.label, hidden: state.hidden, expression: state.expression };
-      const idx = states.findIndex(s => s.id === stateId);
-      component.set(key, idx >= 0
-        ? states.map(s => s.id === stateId ? entry : s)
-        : [...states, entry]
-      );
-    },
-
-    removeState(component, stateId, exported) {
-      const dsApi = this.getDataSourceApi();
-      if (dsApi?.removeState) {
-        dsApi.removeState(component, stateId, exported);
-        return;
-      }
-      const key = exported ? 'publicStates' : 'privateStates';
-      component.set(key, (component.get(key) ?? []).filter(s => s.id !== stateId));
-    },
-
-    getState(component, stateId, exported) {
-      const dsApi = this.getDataSourceApi();
-      if (dsApi?.getState) return dsApi.getState(component, stateId, exported);
-      const key = exported ? 'publicStates' : 'privateStates';
-      return (component.get(key) ?? []).find(s => s.id === stateId) ?? null;
-    },
-
+    // Context joined to every dynamic tool response, so the agent knows what is selected.
     getSelectionState(editor) {
       const dev = editor.Devices.getSelected();
       const page = editor.Pages.getSelected();
@@ -192,7 +60,7 @@
         selector: rule?.selectorsToString?.() ?? null
       };
 
-      // Add hierarchy warnings so SLMs know what's missing
+      // Add hierarchy warnings so SLMs know what is missing
       const warnings = [];
       if (!state.page) warnings.push("No page selected — use page(action:'select') first");
       if (!state.component) warnings.push("No element selected — use component(action:'select') before selector/style/symbol operations");
@@ -202,21 +70,7 @@
       return state;
     },
 
-    _log(tool, action, msg) {
-      console.log(`[MCP ${tool}:${action}] ${msg}`);
-    },
-
-    getOrCreatePersistantId(component) {
-      const dsApi = this.getDataSourceApi();
-      if (dsApi?.getOrCreatePersistantId) return dsApi.getOrCreatePersistantId(component);
-      const id = component.get('id-plugin-data-source');
-      if (id) return id;
-      const newId = `${component.ccid}-${Math.round(Math.random() * 10000)}`;
-      component.set('id-plugin-data-source', newId);
-      return newId;
-    },
-
-    // Query capabilities registry and return as JSON-serializable tool definitions
+    // Capabilities the current page exposes, turned into MCP tools by the Rust side.
     getCapabilities() {
       const caps = window.grapesjsAiCapabilities;
       if (!caps?.getAllCapabilities) return [];

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 lexoyo and Silex Labs foundation
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or any later version.
  */
 

--- a/desktop/src-tauri/src/mcp.rs
+++ b/desktop/src-tauri/src/mcp.rs
@@ -1,4 +1,13 @@
 /*
+ * Silex website builder - desktop app.
+ * Copyright (c) 2023 lexoyo and Silex Labs foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or any later version.
+ */
+
+/*
  * MCP (Model Context Protocol) server for Silex Desktop.
  *
  * Static tools: website, take_screenshot.
@@ -819,15 +828,26 @@ RULES:
 // Server entry point
 // ==========================================================================
 
+/// State shared by every MCP session: the dynamic tools loaded from the page
+/// have to survive a session, otherwise they would be lost on website open.
+fn shared_state() -> (
+    Arc<AtomicU64>,
+    Arc<tokio::sync::RwLock<ToolRouter<SilexMcp>>>,
+    Arc<std::sync::atomic::AtomicBool>,
+) {
+    (
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(tokio::sync::RwLock::new(ToolRouter::new())),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+}
+
 pub async fn start_mcp_server(
     app_handle: tauri::AppHandle,
     pending_evals: PendingEvals,
     port: u16,
 ) {
-    let eval_counter = Arc::new(AtomicU64::new(0));
-    // Shared across all sessions so dynamic tools persist after website open/create
-    let dynamic_tools = Arc::new(tokio::sync::RwLock::new(ToolRouter::new()));
-    let capabilities_loaded = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (eval_counter, dynamic_tools, capabilities_loaded) = shared_state();
 
     let mcp_service = StreamableHttpService::new(
         move || {
@@ -865,9 +885,7 @@ pub async fn start_mcp_stdio(
     app_handle: tauri::AppHandle,
     pending_evals: PendingEvals,
 ) {
-    let eval_counter = Arc::new(AtomicU64::new(0));
-    let dynamic_tools = Arc::new(tokio::sync::RwLock::new(ToolRouter::new()));
-    let capabilities_loaded = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (eval_counter, dynamic_tools, capabilities_loaded) = shared_state();
     let service = SilexMcp::new(app_handle, pending_evals, eval_counter, dynamic_tools, capabilities_loaded);
     tracing::info!("MCP stdio transport starting");
     match service.serve(rmcp::transport::io::stdio()).await {


### PR DESCRIPTION
The MCP bridge exposed 10 helpers, of which the Rust side only ever calls two: what remains was left over from when the tools were static. Verified by running the app: 55 capabilities still load and every dynamic tool still reports its selection state.