### PR TITLE
fix(ci): sign linux bundles with an absolute path

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -166,7 +166,9 @@ jobs:
             echo "::error::No .deb/.rpm bundle found to sign"; exit 1
           fi
           for f in "${BUNDLES[@]}"; do
-            pnpm --dir desktop exec tauri signer sign "$f" > /dev/null
+            # Absolute: `--dir desktop` runs the signer from desktop/, where a path
+            # relative to the repository root does not resolve.
+            pnpm --dir desktop exec tauri signer sign "$PWD/$f" > /dev/null
             if [ ! -s "$f.sig" ]; then
               echo "::error::Signing produced no signature for $f"; exit 1
             fi


### PR DESCRIPTION
The signer runs from desktop/ because of --dir, so the path find returns relative to the repository root never resolved; this broke the first release that actually reached the step.