### PR TITLE
fix(editor): apply margin and padding per side in the style panel

### DIFF
--- a/editor/grapesjs/css-props.ts
+++ b/editor/grapesjs/css-props.ts
@@ -298,6 +298,7 @@ export default (editor: Editor, opts) => {
       name: 'Margin',
       property: 'margin',
       type: 'composite',
+      detached: true,
       defaults: '',
       fixedValues: [ 'initial', 'inherit', 'auto' ],
       full: true,
@@ -336,6 +337,7 @@ export default (editor: Editor, opts) => {
       name: 'Padding',
       property: 'padding',
       type: 'composite',
+      detached: true,
       fixedValues: [ 'initial', 'inherit', 'auto' ],
       full: true,
       properties: [{


### PR DESCRIPTION
The Margin and Padding composite properties are now detached, so setting a single side writes that longhand instead of the margin/padding shorthand.