### PR TITLE
 Fix Windows ESM config loading

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -16,6 +16,8 @@
  */
 
 import { readFile } from 'fs/promises'
+import { jest } from '@jest/globals'
+import { pathToFileURL } from 'node:url'
 import { ServerConfig } from './config.js'
 
 const envKeys = ['SILEX_URL', 'SILEX_PROTOCOL', 'SILEX_HOST', 'SILEX_PORT'] as const
@@ -50,5 +52,30 @@ describe('server URL configuration', () => {
     process.env.SILEX_PORT = '6805'
 
     expect(new ServerConfig().url).toBe('http://192.168.1.179:6805')
+  })
+})
+
+describe('server config file loading', () => {
+  test('loads the config file through a file URL', async () => {
+    const config = new ServerConfig()
+    const addPlugin = jest.spyOn(config, 'addPlugin').mockResolvedValue(config)
+
+    await config.loadSilexConfig()
+
+    expect(addPlugin).toHaveBeenCalledWith(pathToFileURL(config.configFilePath).href, {})
+  })
+
+  test('ignores an ESM module-not-found error for the config file itself', async () => {
+    const config = new ServerConfig()
+    const error = Object.assign(new Error('Cannot find module'), {
+      code: 'ERR_MODULE_NOT_FOUND',
+      url: pathToFileURL(config.configFilePath).href,
+    })
+    jest.spyOn(config, 'addPlugin').mockRejectedValue(error)
+    const info = jest.spyOn(console, 'info').mockImplementation()
+
+    await expect(config.loadSilexConfig()).resolves.toBeUndefined()
+
+    info.mockRestore()
   })
 })

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -65,17 +65,13 @@ describe('server config file loading', () => {
     expect(addPlugin).toHaveBeenCalledWith(pathToFileURL(config.configFilePath).href, {})
   })
 
-  test('ignores an ESM module-not-found error for the config file itself', async () => {
+  test('preserves a user config URL', async () => {
     const config = new ServerConfig()
-    const error = Object.assign(new Error('Cannot find module'), {
-      code: 'ERR_MODULE_NOT_FOUND',
-      url: pathToFileURL(config.configFilePath).href,
-    })
-    jest.spyOn(config, 'addPlugin').mockRejectedValue(error)
-    const info = jest.spyOn(console, 'info').mockImplementation()
+    config.userConfigPath = 'file:///tmp/silex-config.js'
+    const addPlugin = jest.spyOn(config, 'addPlugin').mockResolvedValue(config)
 
-    await expect(config.loadSilexConfig()).resolves.toBeUndefined()
+    await config.loadUserConfig()
 
-    info.mockRestore()
+    expect(addPlugin).toHaveBeenCalledWith(config.userConfigPath, {})
   })
 })

--- a/server/config.ts
+++ b/server/config.ts
@@ -36,6 +36,8 @@ import { ConnectorType } from '~/common/types.js'
 import { FsHosting } from './connectors/FsHosting.js'
 import { pathToFileURL } from 'node:url'
 
+const URL_SCHEME = /^[a-z][a-z0-9+.-]+:/i
+
 /**
  * Config types definitions
  */
@@ -149,7 +151,10 @@ export class ServerConfig extends Config {
       console.info('> Loading user config', this.userConfigPath)
       try {
         // Initiate the process with the config file which is just another plugin
-        await this.addPlugin(pathToFileURL(this.userConfigPath).href, {})
+        const userConfigLocation = URL_SCHEME.test(this.userConfigPath)
+          ? this.userConfigPath
+          : pathToFileURL(this.userConfigPath).href
+        await this.addPlugin(userConfigLocation, {})
       } catch (e) {
         throw new Error(`\nUser config file ${this.userConfigPath} error:\n\n\t${e.message}\n\n`, { cause: e })
       }
@@ -167,10 +172,7 @@ export class ServerConfig extends Config {
       await this.addPlugin(pathToFileURL(this.configFilePath).href, {})
     } catch(e) {
       // Check if the error is about the config file not found and not another module not found in the config file
-      if(
-        (e.code === 'MODULE_NOT_FOUND' && (!e.requireStack || !e.requireStack.find(path => path === this.configFilePath))) ||
-        (e.code === 'ERR_MODULE_NOT_FOUND' && e.url === pathToFileURL(this.configFilePath).href)
-      ) {
+      if(e.code === 'MODULE_NOT_FOUND' && (!e.requireStack || !e.requireStack.find(path => path === this.configFilePath))) {
         console.info('> /!\\ Config file not found', this.configFilePath)
       } else {
         throw new Error(`Error in config file ${this.configFilePath}: ${e.message}`, { cause: e })

--- a/server/config.ts
+++ b/server/config.ts
@@ -24,7 +24,7 @@
  * @class default config for Silex server
  */
 
-import { Config, Plugin } from '~/common/silex-plugins/index.js'
+import { Config } from '~/common/silex-plugins/index.js'
 import { join, resolve } from 'path'
 import { CLIENT_CONFIG_FILE_NAME } from '~/common/constants.js'
 import { Application, Request, Response, Router } from 'express'
@@ -34,6 +34,7 @@ import { FsStorage } from './connectors/FsStorage.js'
 import { Connector } from './connectors/connectors.js'
 import { ConnectorType } from '~/common/types.js'
 import { FsHosting } from './connectors/FsHosting.js'
+import { pathToFileURL } from 'node:url'
 
 /**
  * Config types definitions
@@ -50,8 +51,8 @@ export class ServerConfig extends Config {
   public port = process.env.SILEX_PORT
   public debug = process.env.SILEX_DEBUG === 'true'
   public url = process.env.SILEX_URL?.replace(/\/$/, '') ?? `${process.env.SILEX_PROTOCOL}://${process.env.SILEX_HOST}:${process.env.SILEX_PORT}`
-  public userConfigPath: Plugin | undefined = process.env.SILEX_SERVER_CONFIG
-  public configFilePath: Plugin = resolve(__dirname, '../../../server/deploy/.silex.js')
+  public userConfigPath: string | undefined = process.env.SILEX_SERVER_CONFIG
+  public configFilePath: string = resolve(__dirname, '../../../server/deploy/.silex.js')
 
   // All connectors or just the storage or hosting connectors
   getConnectors(type: ConnectorType | string | null = null): Connector[] {
@@ -148,7 +149,7 @@ export class ServerConfig extends Config {
       console.info('> Loading user config', this.userConfigPath)
       try {
         // Initiate the process with the config file which is just another plugin
-        await this.addPlugin(this.userConfigPath, {})
+        await this.addPlugin(pathToFileURL(this.userConfigPath).href, {})
       } catch (e) {
         throw new Error(`\nUser config file ${this.userConfigPath} error:\n\n\t${e.message}\n\n`, { cause: e })
       }
@@ -163,10 +164,13 @@ export class ServerConfig extends Config {
     console.info('> Loading config', this.configFilePath)
     try {
       // Initiate the process with the config file which is just another plugin
-      await this.addPlugin(this.configFilePath, {})
+      await this.addPlugin(pathToFileURL(this.configFilePath).href, {})
     } catch(e) {
       // Check if the error is about the config file not found and not another module not found in the config file
-      if(e.code === 'MODULE_NOT_FOUND' && (!e.requireStack || !e.requireStack.find(path => path === this.configFilePath))) {
+      if(
+        (e.code === 'MODULE_NOT_FOUND' && (!e.requireStack || !e.requireStack.find(path => path === this.configFilePath))) ||
+        (e.code === 'ERR_MODULE_NOT_FOUND' && e.url === pathToFileURL(this.configFilePath).href)
+      ) {
         console.info('> /!\\ Config file not found', this.configFilePath)
       } else {
         throw new Error(`Error in config file ${this.configFilePath}: ${e.message}`, { cause: e })


### PR DESCRIPTION
Closes #1824
Convert server-side filesystem config paths to `file:` URLs before dynamic import, so Windows absolute paths do not become unsupported `c:` ESM URLs.
Also handles `ERR_MODULE_NOT_FOUND` when the default `.silex.js` file itself is absent, while preserving real module-loading failures.
 Tests: - `corepack pnpm test -- server/config.test.ts --runInBand`

