### PR TITLE
fix: server parity — honor permalink at publish, git init on main

### DIFF
--- a/desktop/src-tauri/src/integrations/git.rs
+++ b/desktop/src-tauri/src/integrations/git.rs
@@ -120,7 +120,9 @@ impl Git {
     }
 
     fn init(&self, site: &Path) -> Result<(), String> {
-        self.run(site, &["init"])?;
+        // -b main: the default branch name depends on the user's git config,
+        // and publishing pushes to main
+        self.run(site, &["init", "-b", "main"])?;
 
         // Committing needs a name and a mail address, and the user may have
         // never set any. Theirs is used when they have one, and the one made

--- a/server-rust/src/routes/publication.rs
+++ b/server-rust/src/routes/publication.rs
@@ -58,6 +58,11 @@ pub struct ClientSideFile {
     /// Path where the file is published
     pub path: String,
 
+    /// Pretty path taking precedence over `path`, when the editor's permalink
+    /// plugin rewrites URLs (e.g. `/about` instead of `/about.html`)
+    #[serde(default)]
+    pub permalink: Option<String>,
+
     /// File content, for the files the editor generates
     #[serde(default)]
     pub content: Option<String>,
@@ -100,7 +105,7 @@ async fn publish_website(
         };
 
         files.push(File {
-            path: file.path,
+            path: file.permalink.unwrap_or(file.path),
             content,
         });
     }


### PR DESCRIPTION
Aligns server-rust publish on the Node behavior (`permalink ?? path`) and makes desktop git repos start on `main`.