### PR TITLE
fix(publication): omit empty lang and fall back to page name for title

### DIFF
--- a/editor/grapesjs/PublicationManager.test.ts
+++ b/editor/grapesjs/PublicationManager.test.ts
@@ -1,0 +1,63 @@
+/*
+ * @jest-environment jsdom
+ */
+
+import { expect, jest, describe, it, beforeEach } from '@jest/globals'
+import grapesjs, { Editor } from 'grapesjs'
+import { WebsiteSettings } from '~/common/types'
+import { PublicationManager } from './PublicationManager'
+
+// Prevent lit-html from being imported (it is a peer dependency and breaks the tests)
+jest.mock('lit-html', () => ({}))
+
+describe('PublicationManager html output', () => {
+  let editor: Editor
+
+  beforeEach(() => {
+    /* @ts-ignore */
+    editor = grapesjs.init({
+      headless: true,
+      storageManager: { autoload: false },
+    })
+    editor.getModel().set('config', { getEditor: () => editor, publicationTransformers: [] })
+  })
+
+  async function getHtml(siteSettings: WebsiteSettings, pageSettings: WebsiteSettings, pageName: string) {
+    const page = editor.Pages.getAll()[0]
+    page.set('name', pageName)
+    page.set('settings', pageSettings)
+    const manager = new PublicationManager(editor, { websiteId: 'test' })
+    for await (const file of manager.getHtmlFilesYield(siteSettings, () => undefined)) {
+      if (file) return file.html as string
+    }
+    throw new Error('No file yielded')
+  }
+
+  it('omits the lang attribute when no language is set', async () => {
+    const html = await getHtml({}, {}, 'Home')
+    expect(html).toContain('<html>')
+    expect(html).not.toContain('lang=')
+  })
+
+  it('writes the lang attribute when a language is set', async () => {
+    const html = await getHtml({ lang: 'fr' }, {}, 'Home')
+    expect(html).toContain('<html lang="fr">')
+  })
+
+  it('falls back to the page name when no title is set', async () => {
+    const html = await getHtml({}, {}, 'My page')
+    expect(html).toContain('<title>My page</title>')
+  })
+
+  it('prefers the title setting over the page name', async () => {
+    const html = await getHtml({}, { title: 'Custom title' }, 'My page')
+    expect(html).toContain('<title>Custom title</title>')
+    expect(html).not.toContain('<title>My page</title>')
+  })
+
+  it('does not save the fallback title into the page settings', async () => {
+    await getHtml({}, {}, 'My page')
+    const settings = editor.Pages.getAll()[0].get('settings') as WebsiteSettings
+    expect(settings?.title).toBeUndefined()
+  })
+})

--- a/editor/grapesjs/PublicationManager.ts
+++ b/editor/grapesjs/PublicationManager.ts
@@ -577,7 +577,12 @@ export class PublicationManager {
       })
 
       // Useful data for HTML result
-      const title = getSetting('title')
+      // Fall back to the page name when no title is set, at publish time only, so
+      // that the title keeps following the page name if the user renames the page
+      const title = getSetting('title').trim() || (page.get('name') || '').trim()
+      // An empty lang attribute is worse than no lang at all for screen readers,
+      // and we do not want to guess a default language, so omit it when not set
+      const lang = getSetting('lang').trim()
       const favicon = getSetting('favicon')
       const viewportMeta = this.ensureViewportMeta(clonedSiteSettings?.head || '', pageSettings?.head || '')
       const generatorMeta = this.ensureGeneratorMeta(clonedSiteSettings?.head || '', pageSettings?.head || '')
@@ -585,7 +590,7 @@ export class PublicationManager {
       // Return the HTML file
       yield {
         html: `<!DOCTYPE html>
-<html lang="${getSetting('lang')}">
+<html${lang ? ` lang="${lang}"` : ''}>
 <head>
 <meta charset="UTF-8">
 ${viewportMeta}


### PR DESCRIPTION
>What does this PR do?

Fixes #1734.

- Omit the `lang` attribute when no language is configured instead of generating `lang=""`.
- Fall back to the page name for `<title>` when no title is configured.
- The fallback happens at publish time and is not persisted in page settings.
- No default language is guessed.
- Publishing is not blocked when these settings are empty.

>Testing

- Added tests covering the requested cases.
- All 5 new tests pass.
- Full editor test suite passes.
- ESLint passes.
- Tested the published output in the browser.