### PR TITLE
feat(editor): use 11ty for all sites, even without data source

### DIFF
--- a/editor/grapesjs/PublicationManager.ts
+++ b/editor/grapesjs/PublicationManager.ts
@@ -25,6 +25,8 @@ import { ClientEvent } from '../events'
 import { resetRenderComponents, resetRenderCssRules, transformPermalink, transformFiles, transformPath, renderComponents, renderCssRules } from '../publication-transformers'
 import { hashString } from '../utils'
 import { displayedToStored, isExternalUrl } from '../assetUrl'
+import { getAllDataSources } from '@silexlabs/grapesjs-data-source'
+import { EleventyDataSourceId } from './cms/DataSource'
 
 /**
  * @fileoverview Publication manager for Silex
@@ -238,6 +240,42 @@ export class PublicationManager {
     }
   }
 
+  /**
+   * The 11ty directory data file, published with every website
+   *
+   * Publishing runs 11ty on the whole site, whether or not it reads data. On a
+   * site that does not, 11ty would rename `about.html` to `about/index.html`,
+   * which breaks every link in the site, and read the pages as Liquid
+   * templates, which empties anything between double braces and fails the
+   * build on anything between brace and percent. This file tells it to keep
+   * the file names and to leave the pages alone.
+   *
+   * On a site that reads a data source, the front matter of each page says
+   * what to do, so this says nothing and lets them.
+   */
+  eleventyDirectoryData(): ClientSideFile {
+    const readsData = getAllDataSources()
+      .filter(dataSource => dataSource.id !== EleventyDataSourceId)
+      .length > 0
+    const content = readsData
+      ? 'export default {}\n'
+      : `export default {
+  // Keep the name and the place of every page: \`about.html\` stays
+  // \`about.html\`, so the links inside the site keep working
+  permalink: data => \`\${data.page.filePathStem}.html\`,
+  // The pages are already what they should be, not templates to render
+  templateEngineOverride: false,
+}
+`
+    return {
+      // Named after the folder it sits in, which is how 11ty reads a directory
+      // data file
+      path: '/public.11tydata.js',
+      content,
+      type: ClientSideFileType.OTHER,
+    } as ClientSideFile
+  }
+
   async getPublicationData(projectData, siteSettings, preventDefault: () => void): Promise<PublicationData> {
     // Data to publish
     // See assetUrl.ts which is a default transformer, always present
@@ -282,6 +320,7 @@ export class PublicationManager {
             type: ClientSideFileType.ASSET, // Replaces grapesjs's 'image' type
           } as ClientSideFile
         }))
+    files.push(this.eleventyDirectoryData())
     // Create the data to send to the server
     const data: PublicationData = {
       ...projectData,

--- a/server/plugins/GitlabHostingConnector.ts
+++ b/server/plugins/GitlabHostingConnector.ts
@@ -152,6 +152,10 @@ export default class GitlabHostingConnector extends GitlabConnector implements H
     job.logs = [[`Publishing to ${this.displayName}`]]
     job.errors = [[]]
     /* Configuration file .gitlab-ci.yml contains template for plain html Gitlab pages*/
+    // Note on the file the condition below leaves out: the editor publishes a
+    // `public.11tydata.js` with every website, for the desktop app, which runs
+    // 11ty on all of them. Here 11ty still runs only on a website that reads a
+    // data source, as it always has.
     const pathYml = '.gitlab-ci.yml'
     const contentYml = dedent`
       ${SILEX_OVERWRITE_NOTICE}
@@ -162,7 +166,7 @@ export default class GitlabHostingConnector extends GitlabConnector implements H
       pages:
         stage: deploy
         environment: production
-        script:${files.find(file => file.path.includes('.11tydata.')) ? `
+        script:${files.find(file => file.path.includes('.11tydata.') && !file.path.endsWith('public.11tydata.js')) ? `
           - npx @11ty/eleventy@v3.0.0-alpha.20 --input=public --output=_site
           - mkdir -p public/css public/assets && cp -R public/css public/assets _site/
           - rm -rf public && mv _site public`

--- a/server/plugins/GitlabHostingConnector.ts
+++ b/server/plugins/GitlabHostingConnector.ts
@@ -34,6 +34,8 @@ const waitTimeOut = 5000 /* for wait loop waiting for job to appear */
 const jobPollInterval = 10000 /* poll job status every 10 seconds */
 const jobCompletionTimeOut = 45 * 60 * 1000 /* 45 minutes max for job completion */
 const SILEX_OVERWRITE_NOTICE = '# silexOverwrite: true'
+// Kept in step with ELEVENTY_VERSION in desktop/src-tauri/src/integrations/pipeline.rs
+const ELEVENTY_VERSION = '3.1.6'
 
 // GitLab job statuses that indicate the job is still running
 const GITLAB_RUNNING_STATUSES = ['created', 'waiting_for_resource', 'preparing', 'pending', 'running']
@@ -152,32 +154,41 @@ export default class GitlabHostingConnector extends GitlabConnector implements H
     job.logs = [[`Publishing to ${this.displayName}`]]
     job.errors = [[]]
     /* Configuration file .gitlab-ci.yml contains template for plain html Gitlab pages*/
-    // Note on the file the condition below leaves out: the editor publishes a
-    // `public.11tydata.js` with every website, for the desktop app, which runs
-    // 11ty on all of them. Here 11ty still runs only on a website that reads a
-    // data source, as it always has.
     const pathYml = '.gitlab-ci.yml'
     const contentYml = dedent`
       ${SILEX_OVERWRITE_NOTICE}
       # You will want to remove these lines if you customize your build process
       # Silex will overwrite this file unless you remove these lines
       # This is the default build process for plain eleventy sites
-      image: node:20
+      image: node:22-slim
       pages:
         stage: deploy
         environment: production
-        script:${files.find(file => file.path.includes('.11tydata.') && !file.path.endsWith('public.11tydata.js')) ? `
-          - npx @11ty/eleventy@v3.0.0-alpha.20 --input=public --output=_site
-          - mkdir -p public/css public/assets && cp -R public/css public/assets _site/
-          - rm -rf public && mv _site public`
-    : ''}
+        timeout: 15 minutes
+        resource_group: pages
+        cache:
+          key: silex-npm
+          paths:
+            - .npm
+        variables:
+          npm_config_cache: .npm
+        script:
+          - npx @11ty/eleventy@${ELEVENTY_VERSION} --input=public --output=_site
+          - cp -R public/*/ _site/
           - echo "The site will be deployed to $CI_PAGES_URL"
+        pages:
+          publish: _site
+        # Before GitLab 17.10 the folder above is not added here on its own
         artifacts:
           paths:
-            - public
+            - _site
         rules:
-          - if: '$CI_COMMIT_TAG'
+          # What Silex tags when publishing. Another tag is the user's own business
+          - if: '$CI_COMMIT_TAG =~ /^_silex_/'
           - if: '$CI_PIPELINE_SOURCE == "trigger"'
+          - if: '$CI_PIPELINE_SOURCE == "api"'
+          - if: '$CI_PIPELINE_SOURCE == "web"'
+          - if: '$CI_PIPELINE_SOURCE == "schedule"'
     `
     try {
       job.message = `Checking if ${pathYml} needs to be created or updated...`


### PR DESCRIPTION
Writes `public/public.11tydata.js` at every publication so 11ty keeps page names and does not render pages as templates, and runs 11ty on every GitLab publication with the pipeline the desktop app already uses. Refs #1739.