### PR TITLE
feat(editor): warn about images missing alt text

### DIFF
--- a/editor/grapesjs/PublicationManager.test.ts
+++ b/editor/grapesjs/PublicationManager.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { expect, jest, describe, it, beforeEach } from '@jest/globals'
-import grapesjs, { Editor } from 'grapesjs'
+import grapesjs, { Component, Editor } from 'grapesjs'
 import { WebsiteSettings } from '~/common/types'
 import { PublicationManager } from './PublicationManager'
 
@@ -59,5 +59,47 @@ describe('PublicationManager html output', () => {
     await getHtml({}, {}, 'My page')
     const settings = editor.Pages.getAll()[0].get('settings') as WebsiteSettings
     expect(settings?.title).toBeUndefined()
+  })
+
+  it('finds only images that have no alt attribute', () => {
+    const page = editor.Pages.getAll()[0]
+    const body = page.getMainComponent()
+    body.components().add([
+      { tagName: 'img', attributes: { src: '/missing-alt.png' } },
+      { tagName: 'img', attributes: { src: '/decorative.png', alt: '' } },
+      { tagName: 'img', attributes: { src: '/described.png', alt: 'A described image' } },
+    ])
+    const manager = new PublicationManager(editor, { websiteId: 'test' })
+    const getImagesMissingAlt = (manager as unknown as {
+      getImagesMissingAlt(component: Component): Component[]
+    }).getImagesMissingAlt.bind(manager)
+
+    const imagesMissingAlt = getImagesMissingAlt(body)
+
+    expect(imagesMissingAlt).toHaveLength(1)
+    expect(imagesMissingAlt[0].getAttributes().src).toBe('/missing-alt.png')
+  })
+
+  it('warns before publication when images are missing an alt attribute', () => {
+    const page = editor.Pages.getAll()[0]
+    page.set('name', 'Home')
+    const body = page.getMainComponent()
+    const [missingAltImage] = body.components().add([
+      { tagName: 'img', attributes: { src: '/missing-alt.png' } },
+      { tagName: 'img', attributes: { src: '/decorative.png', alt: '' } },
+    ])
+    const manager = new PublicationManager(editor, { websiteId: 'test' })
+    const checkSeoTags = (manager as unknown as {
+      checkSeoTags(siteSettings: WebsiteSettings): void
+    }).checkSeoTags.bind(manager)
+    const runCommand = jest.spyOn(editor, 'runCommand')
+
+    checkSeoTags({})
+
+    expect(runCommand).toHaveBeenCalledWith('notifications:add', expect.objectContaining({
+      id: `accessibility-validation-alt-${page.getId()}`,
+      componentId: missingAltImage.getId(),
+      group: 'accessibility-validation',
+    }))
   })
 })

--- a/editor/grapesjs/PublicationManager.ts
+++ b/editor/grapesjs/PublicationManager.ts
@@ -17,7 +17,7 @@
 
 import { getPageSlug } from '~/common/page'
 import { ApiConnectorLoggedInPostMessage, ApiConnectorLoginQuery, ApiPublicationPublishBody, ClientSideFile, ClientSideFileType, ConnectorData, ConnectorType, ConnectorUser, JobStatus, Initiator, PublicationData, PublicationJobData, PublicationSettings, WebsiteData, WebsiteFile, WebsiteId, WebsiteSettings } from '~/common/types'
-import { Editor } from 'grapesjs'
+import { Component, Editor } from 'grapesjs'
 import { PublicationUi } from './PublicationUi'
 import { getUser, logout, publicationStatus, publish } from '../api'
 import { API_CONNECTOR_LOGIN, API_CONNECTOR_PATH, API_PATH, SILEX_VERSION } from '~/common/constants'
@@ -459,6 +459,29 @@ export class PublicationManager {
   }
 
   /**
+   * Find images which have not been given an alt attribute.
+   * An empty alt attribute is intentional for decorative images and must not
+   * be reported as missing.
+   */
+  private getImagesMissingAlt(component: Component): Component[] {
+    const images: Component[] = []
+
+    const visit = (current: Component) => {
+      const tagName = current.get('tagName')?.toLowerCase()
+      const attributes = current.getAttributes()
+
+      if (tagName === 'img' && !Object.prototype.hasOwnProperty.call(attributes, 'alt')) {
+        images.push(current)
+      }
+
+      current.components().forEach(visit)
+    }
+
+    visit(component)
+    return images
+  }
+
+  /**
    * Check for missing SEO tags and emit warnings
    * @param siteSettings - Site settings
    */
@@ -477,6 +500,17 @@ export class PublicationManager {
       const bodyComponent = page.getMainComponent()
       const componentId = bodyComponent?.getId()
       const pageId = page.getId()
+
+      const imagesMissingAlt = bodyComponent ? this.getImagesMissingAlt(bodyComponent) : []
+      if (imagesMissingAlt.length) {
+        this.editor.runCommand('notifications:add', {
+          id: `accessibility-validation-alt-${pageId}`,
+          type: 'warning',
+          message: `Page "${pageName}": ${imagesMissingAlt.length} image${imagesMissingAlt.length === 1 ? '' : 's'} ${imagesMissingAlt.length === 1 ? 'is' : 'are'} missing an alt attribute. Add alt text, or use alt="" for decorative images.`,
+          componentId: imagesMissingAlt[0].getId(),
+          group: 'accessibility-validation',
+        })
+      }
 
       // Check for lang attribute
       const lang = getSetting(pageSettings, 'lang')


### PR DESCRIPTION
>>Summary
Adds a non-blocking pre-publish accessibility warning when a page contains images without an `alt` attribute.

- Reports the number of images missing `alt` per page
- Links the warning to the first affected image
- Treats explicit `alt=""` as handled for decorative images
- Adds focused unit tests

>>Testing

- `PublicationManager.test.ts`: 7 tests passed
- ESLint passed